### PR TITLE
refactor(zerna.io): improve handling of seo load

### DIFF
--- a/packages/zerna.io/graphql.schema.json
+++ b/packages/zerna.io/graphql.schema.json
@@ -10759,6 +10759,18 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "key",
+						"description": null,
+						"args": [],
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "locale",
 						"description": "System Locale field",
 						"args": [],
@@ -11052,18 +11064,6 @@
 						"deprecationReason": null
 					},
 					{
-						"name": "slug",
-						"description": null,
-						"args": [],
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
 						"name": "stage",
 						"description": "System stage field",
 						"args": [],
@@ -11310,6 +11310,18 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "key",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "localizations",
 						"description": "Inline mutations for managing document localizations excluding the default locale",
 						"type": {
@@ -11327,18 +11339,6 @@
 						"type": {
 							"kind": "INPUT_OBJECT",
 							"name": "SeoCreateOneInlineInput",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug",
-						"description": null,
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
 							"ofType": null
 						},
 						"defaultValue": null,
@@ -12062,6 +12062,142 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "key",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_contains",
+						"description": "All values containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_ends_with",
+						"description": "All values ending with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_contains",
+						"description": "All values not containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_ends_with",
+						"description": "All values not ending with the given string",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_starts_with",
+						"description": "All values not starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_starts_with",
+						"description": "All values starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "publishedAt",
 						"description": null,
 						"type": {
@@ -12234,142 +12370,6 @@
 						"deprecationReason": null
 					},
 					{
-						"name": "slug",
-						"description": null,
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_contains",
-						"description": "All values containing the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_ends_with",
-						"description": "All values ending with the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_in",
-						"description": "All values that are contained in given list.",
-						"type": {
-							"kind": "LIST",
-							"name": null,
-							"ofType": {
-								"kind": "NON_NULL",
-								"name": null,
-								"ofType": {
-									"kind": "SCALAR",
-									"name": "String",
-									"ofType": null
-								}
-							}
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not",
-						"description": "All values that are not equal to given value.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not_contains",
-						"description": "All values not containing the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not_ends_with",
-						"description": "All values not ending with the given string",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not_in",
-						"description": "All values that are not contained in given list.",
-						"type": {
-							"kind": "LIST",
-							"name": null,
-							"ofType": {
-								"kind": "NON_NULL",
-								"name": null,
-								"ofType": {
-									"kind": "SCALAR",
-									"name": "String",
-									"ofType": null
-								}
-							}
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not_starts_with",
-						"description": "All values not starting with the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_starts_with",
-						"description": "All values starting with the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
 						"name": "updatedAt",
 						"description": null,
 						"type": {
@@ -12531,6 +12531,18 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "key_ASC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_DESC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "publishedAt_ASC",
 						"description": null,
 						"isDeprecated": false,
@@ -12538,18 +12550,6 @@
 					},
 					{
 						"name": "publishedAt_DESC",
-						"description": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_ASC",
-						"description": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_DESC",
 						"description": null,
 						"isDeprecated": false,
 						"deprecationReason": null
@@ -12600,6 +12600,18 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "key",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "localizations",
 						"description": "Manage document localizations",
 						"type": {
@@ -12617,18 +12629,6 @@
 						"type": {
 							"kind": "INPUT_OBJECT",
 							"name": "SeoUpdateOneInlineInput",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug",
-						"description": null,
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
 							"ofType": null
 						},
 						"defaultValue": null,
@@ -13757,6 +13757,142 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "key",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_contains",
+						"description": "All values containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_ends_with",
+						"description": "All values ending with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_contains",
+						"description": "All values not containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_ends_with",
+						"description": "All values not ending with the given string",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_starts_with",
+						"description": "All values not starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_starts_with",
+						"description": "All values starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "publishedAt",
 						"description": null,
 						"type": {
@@ -13922,142 +14058,6 @@
 						"type": {
 							"kind": "INPUT_OBJECT",
 							"name": "SeoWhereInput",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug",
-						"description": null,
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_contains",
-						"description": "All values containing the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_ends_with",
-						"description": "All values ending with the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_in",
-						"description": "All values that are contained in given list.",
-						"type": {
-							"kind": "LIST",
-							"name": null,
-							"ofType": {
-								"kind": "NON_NULL",
-								"name": null,
-								"ofType": {
-									"kind": "SCALAR",
-									"name": "String",
-									"ofType": null
-								}
-							}
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not",
-						"description": "All values that are not equal to given value.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not_contains",
-						"description": "All values not containing the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not_ends_with",
-						"description": "All values not ending with the given string",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not_in",
-						"description": "All values that are not contained in given list.",
-						"type": {
-							"kind": "LIST",
-							"name": null,
-							"ofType": {
-								"kind": "NON_NULL",
-								"name": null,
-								"ofType": {
-									"kind": "SCALAR",
-									"name": "String",
-									"ofType": null
-								}
-							}
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_not_starts_with",
-						"description": "All values not starting with the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
-							"ofType": null
-						},
-						"defaultValue": null,
-						"isDeprecated": false,
-						"deprecationReason": null
-					},
-					{
-						"name": "slug_starts_with",
-						"description": "All values starting with the given string.",
-						"type": {
-							"kind": "SCALAR",
-							"name": "String",
 							"ofType": null
 						},
 						"defaultValue": null,
@@ -14348,7 +14348,7 @@
 						"deprecationReason": null
 					},
 					{
-						"name": "slug",
+						"name": "key",
 						"description": null,
 						"type": {
 							"kind": "SCALAR",

--- a/packages/zerna.io/src/lib/cms/page/queries.ts
+++ b/packages/zerna.io/src/lib/cms/page/queries.ts
@@ -1,9 +1,11 @@
+import type { PageSummaryFragment } from '$lib/types/graphql';
+import { client } from '$lib/clients/graphql-client';
 import { gql } from 'graphql-request';
 
 export const allPages = gql`
 	query AllPages {
 		pages {
-			slug
+			key
 			seo {
 				description
 				keywords
@@ -12,14 +14,14 @@ export const allPages = gql`
 	}
 `;
 
-export const pageBySlug = gql`
-	query PageBySlug($slug: String!) {
-		page(where: { slug: $slug }) {
+export const pageByKey = gql`
+	query PageBySlug($key: String!) {
+		page(where: { key: $key }) {
 			title
 			content {
 				html
 			}
-			slug
+			key
 			seo {
 				description
 				keywords
@@ -27,3 +29,23 @@ export const pageBySlug = gql`
 		}
 	}
 `;
+
+export const getPageSummary = async (key: string) => {
+	try {
+		const variables = {
+			key
+		};
+		const { page }: { page: PageSummaryFragment } = await client.request(pageByKey, variables);
+		return {
+			status: 200,
+			body: { page }
+		};
+	} catch (e) {
+		return {
+			status: e.status,
+			body: {
+				error: 'error'
+			}
+		};
+	}
+};

--- a/packages/zerna.io/src/lib/cms/page/schema.graphql
+++ b/packages/zerna.io/src/lib/cms/page/schema.graphql
@@ -3,7 +3,7 @@ fragment PageSummary on Page {
 	content {
 		html
 	}
-	slug
+	key
 	seo {
 		description
 		keywords

--- a/packages/zerna.io/src/lib/types/graphql.ts
+++ b/packages/zerna.io/src/lib/types/graphql.ts
@@ -1490,6 +1490,7 @@ export type Page = Node & {
 	history: Array<Version>;
 	/** The unique identifier */
 	id: Scalars['ID'];
+	key?: Maybe<Scalars['String']>;
 	/** System Locale field */
 	locale: Locale;
 	/** Get the other localizations for this document */
@@ -1500,7 +1501,6 @@ export type Page = Node & {
 	publishedBy?: Maybe<User>;
 	scheduledIn: Array<ScheduledOperation>;
 	seo?: Maybe<Seo>;
-	slug?: Maybe<Scalars['String']>;
 	/** System stage field */
 	stage: Stage;
 	title: Scalars['String'];
@@ -1586,10 +1586,10 @@ export type PageCreateInput = {
 	/** content input for default locale (en) */
 	content?: InputMaybe<Scalars['RichTextAST']>;
 	createdAt?: InputMaybe<Scalars['DateTime']>;
+	key?: InputMaybe<Scalars['String']>;
 	/** Inline mutations for managing document localizations excluding the default locale */
 	localizations?: InputMaybe<PageCreateLocalizationsInput>;
 	seo?: InputMaybe<SeoCreateOneInlineInput>;
-	slug?: InputMaybe<Scalars['String']>;
 	/** title input for default locale (en) */
 	title: Scalars['String'];
 	updatedAt?: InputMaybe<Scalars['DateTime']>;
@@ -1696,6 +1696,25 @@ export type PageManyWhereInput = {
 	id_not_starts_with?: InputMaybe<Scalars['ID']>;
 	/** All values starting with the given string. */
 	id_starts_with?: InputMaybe<Scalars['ID']>;
+	key?: InputMaybe<Scalars['String']>;
+	/** All values containing the given string. */
+	key_contains?: InputMaybe<Scalars['String']>;
+	/** All values ending with the given string. */
+	key_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are contained in given list. */
+	key_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values that are not equal to given value. */
+	key_not?: InputMaybe<Scalars['String']>;
+	/** All values not containing the given string. */
+	key_not_contains?: InputMaybe<Scalars['String']>;
+	/** All values not ending with the given string */
+	key_not_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are not contained in given list. */
+	key_not_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values not starting with the given string. */
+	key_not_starts_with?: InputMaybe<Scalars['String']>;
+	/** All values starting with the given string. */
+	key_starts_with?: InputMaybe<Scalars['String']>;
 	publishedAt?: InputMaybe<Scalars['DateTime']>;
 	/** All values greater than the given value. */
 	publishedAt_gt?: InputMaybe<Scalars['DateTime']>;
@@ -1716,25 +1735,6 @@ export type PageManyWhereInput = {
 	scheduledIn_none?: InputMaybe<ScheduledOperationWhereInput>;
 	scheduledIn_some?: InputMaybe<ScheduledOperationWhereInput>;
 	seo?: InputMaybe<SeoWhereInput>;
-	slug?: InputMaybe<Scalars['String']>;
-	/** All values containing the given string. */
-	slug_contains?: InputMaybe<Scalars['String']>;
-	/** All values ending with the given string. */
-	slug_ends_with?: InputMaybe<Scalars['String']>;
-	/** All values that are contained in given list. */
-	slug_in?: InputMaybe<Array<Scalars['String']>>;
-	/** All values that are not equal to given value. */
-	slug_not?: InputMaybe<Scalars['String']>;
-	/** All values not containing the given string. */
-	slug_not_contains?: InputMaybe<Scalars['String']>;
-	/** All values not ending with the given string */
-	slug_not_ends_with?: InputMaybe<Scalars['String']>;
-	/** All values that are not contained in given list. */
-	slug_not_in?: InputMaybe<Array<Scalars['String']>>;
-	/** All values not starting with the given string. */
-	slug_not_starts_with?: InputMaybe<Scalars['String']>;
-	/** All values starting with the given string. */
-	slug_starts_with?: InputMaybe<Scalars['String']>;
 	updatedAt?: InputMaybe<Scalars['DateTime']>;
 	/** All values greater than the given value. */
 	updatedAt_gt?: InputMaybe<Scalars['DateTime']>;
@@ -1758,10 +1758,10 @@ export enum PageOrderByInput {
 	CreatedAtDesc = 'createdAt_DESC',
 	IdAsc = 'id_ASC',
 	IdDesc = 'id_DESC',
+	KeyAsc = 'key_ASC',
+	KeyDesc = 'key_DESC',
 	PublishedAtAsc = 'publishedAt_ASC',
 	PublishedAtDesc = 'publishedAt_DESC',
-	SlugAsc = 'slug_ASC',
-	SlugDesc = 'slug_DESC',
 	TitleAsc = 'title_ASC',
 	TitleDesc = 'title_DESC',
 	UpdatedAtAsc = 'updatedAt_ASC',
@@ -1771,10 +1771,10 @@ export enum PageOrderByInput {
 export type PageUpdateInput = {
 	/** content input for default locale (en) */
 	content?: InputMaybe<Scalars['RichTextAST']>;
+	key?: InputMaybe<Scalars['String']>;
 	/** Manage document localizations */
 	localizations?: InputMaybe<PageUpdateLocalizationsInput>;
 	seo?: InputMaybe<SeoUpdateOneInlineInput>;
-	slug?: InputMaybe<Scalars['String']>;
 	/** title input for default locale (en) */
 	title?: InputMaybe<Scalars['String']>;
 };
@@ -1931,6 +1931,25 @@ export type PageWhereInput = {
 	id_not_starts_with?: InputMaybe<Scalars['ID']>;
 	/** All values starting with the given string. */
 	id_starts_with?: InputMaybe<Scalars['ID']>;
+	key?: InputMaybe<Scalars['String']>;
+	/** All values containing the given string. */
+	key_contains?: InputMaybe<Scalars['String']>;
+	/** All values ending with the given string. */
+	key_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are contained in given list. */
+	key_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values that are not equal to given value. */
+	key_not?: InputMaybe<Scalars['String']>;
+	/** All values not containing the given string. */
+	key_not_contains?: InputMaybe<Scalars['String']>;
+	/** All values not ending with the given string */
+	key_not_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are not contained in given list. */
+	key_not_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values not starting with the given string. */
+	key_not_starts_with?: InputMaybe<Scalars['String']>;
+	/** All values starting with the given string. */
+	key_starts_with?: InputMaybe<Scalars['String']>;
 	publishedAt?: InputMaybe<Scalars['DateTime']>;
 	/** All values greater than the given value. */
 	publishedAt_gt?: InputMaybe<Scalars['DateTime']>;
@@ -1951,25 +1970,6 @@ export type PageWhereInput = {
 	scheduledIn_none?: InputMaybe<ScheduledOperationWhereInput>;
 	scheduledIn_some?: InputMaybe<ScheduledOperationWhereInput>;
 	seo?: InputMaybe<SeoWhereInput>;
-	slug?: InputMaybe<Scalars['String']>;
-	/** All values containing the given string. */
-	slug_contains?: InputMaybe<Scalars['String']>;
-	/** All values ending with the given string. */
-	slug_ends_with?: InputMaybe<Scalars['String']>;
-	/** All values that are contained in given list. */
-	slug_in?: InputMaybe<Array<Scalars['String']>>;
-	/** All values that are not equal to given value. */
-	slug_not?: InputMaybe<Scalars['String']>;
-	/** All values not containing the given string. */
-	slug_not_contains?: InputMaybe<Scalars['String']>;
-	/** All values not ending with the given string */
-	slug_not_ends_with?: InputMaybe<Scalars['String']>;
-	/** All values that are not contained in given list. */
-	slug_not_in?: InputMaybe<Array<Scalars['String']>>;
-	/** All values not starting with the given string. */
-	slug_not_starts_with?: InputMaybe<Scalars['String']>;
-	/** All values starting with the given string. */
-	slug_starts_with?: InputMaybe<Scalars['String']>;
 	title?: InputMaybe<Scalars['String']>;
 	/** All values containing the given string. */
 	title_contains?: InputMaybe<Scalars['String']>;
@@ -2010,7 +2010,7 @@ export type PageWhereInput = {
 /** References Page record uniquely */
 export type PageWhereUniqueInput = {
 	id?: InputMaybe<Scalars['ID']>;
-	slug?: InputMaybe<Scalars['String']>;
+	key?: InputMaybe<Scalars['String']>;
 };
 
 export type Post = Node & {
@@ -4766,7 +4766,7 @@ export enum _SystemDateTimeFieldVariation {
 export type PageSummaryFragment = {
 	__typename?: 'Page';
 	title: string;
-	slug?: string | null;
+	key?: string | null;
 	content?: { __typename?: 'RichText'; html: string } | null;
 	seo?: { __typename?: 'Seo'; description?: string | null; keywords: Array<string> } | null;
 };

--- a/packages/zerna.io/src/routes/terms.ts
+++ b/packages/zerna.io/src/routes/terms.ts
@@ -1,24 +1,5 @@
-import type { PageSummaryFragment } from '$lib/types/graphql';
-import { client } from '$lib/clients/graphql-client';
-import { pageBySlug } from '$lib/cms/page/queries';
+import { getPageSummary } from '$lib/cms/page/queries';
 
 export const get = async () => {
-	try {
-		const variables = {
-			slug: 'terms'
-		};
-		const { page }: { page: PageSummaryFragment } = await client.request(pageBySlug, variables);
-		return {
-			status: 200,
-			body: { page }
-		};
-	} catch (e) {
-		console.log(e);
-		return {
-			status: e.status,
-			body: {
-				error: 'error'
-			}
-		};
-	}
+	return getPageSummary('terms');
 };


### PR DESCRIPTION
- refactor graphql query and ts function to be more reusable
- still use shadow endoints to avoid boilerplate within svelte files
- shadow endpoints are also practical for the cmd-env functions within an ssr environment

closes #31