### PR TITLE
feat(zerna.io): add i18n via graphcms and finish landing mocks

### DIFF
--- a/packages/application-ui/tsconfig.json
+++ b/packages/application-ui/tsconfig.json
@@ -21,5 +21,5 @@
 			"$lib/*": ["src/lib/*"]
 		}
 	},
-	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte"]
+	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte", "src/lib/utils/arrayts"]
 }

--- a/packages/zerna.io/codegen.yml
+++ b/packages/zerna.io/codegen.yml
@@ -2,7 +2,7 @@ overwrite: true
 schema: ${GRAPHQL_ENDPOINT}
 documents: 'src/**/*.graphql'
 generates:
-  src/lib/types/graphql.ts:
+  src/lib/generated/graphql.ts:
     plugins:
       - 'typescript'
       - 'typescript-operations'

--- a/packages/zerna.io/graphql.schema.json
+++ b/packages/zerna.io/graphql.schema.json
@@ -5398,6 +5398,35 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "createTranslation",
+						"description": "Create one translation",
+						"args": [
+							{
+								"name": "data",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationCreateInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "Translation",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "deleteAsset",
 						"description": "Delete one asset from _all_ existing stages. Returns deleted document.",
 						"args": [
@@ -5899,6 +5928,124 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "deleteManyTranslations",
+						"description": "Delete many Translation documents",
+						"args": [
+							{
+								"name": "where",
+								"description": "Documents to delete",
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationManyWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "BatchPayload",
+								"ofType": null
+							}
+						},
+						"isDeprecated": true,
+						"deprecationReason": "Please use the new paginated many mutation (deleteManyTranslationsConnection)"
+					},
+					{
+						"name": "deleteManyTranslationsConnection",
+						"description": "Delete many Translation documents, return deleted documents",
+						"args": [
+							{
+								"name": "after",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "before",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "first",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "last",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "skip",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Documents to delete",
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationManyWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "TranslationConnection",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "deletePage",
 						"description": "Delete one page from _all_ existing stages. Returns deleted document.",
 						"args": [
@@ -6038,6 +6185,35 @@
 						"type": {
 							"kind": "OBJECT",
 							"name": "Seo",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "deleteTranslation",
+						"description": "Delete one translation from _all_ existing stages. Returns deleted document.",
+						"args": [
+							{
+								"name": "where",
+								"description": "Document to delete",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationWhereUniqueInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "Translation",
 							"ofType": null
 						},
 						"isDeprecated": false,
@@ -7117,6 +7293,272 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "publishManyTranslations",
+						"description": "Publish many Translation documents",
+						"args": [
+							{
+								"name": "locales",
+								"description": "Document localizations to publish",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "publishBase",
+								"description": "Whether to publish the base document",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "to",
+								"description": "Stages to publish documents to",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Stage",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[PUBLISHED]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Identifies documents in each stage to be published",
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationManyWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "withDefaultLocale",
+								"description": "Whether to include the default locale when publishBase is true",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "BatchPayload",
+								"ofType": null
+							}
+						},
+						"isDeprecated": true,
+						"deprecationReason": "Please use the new paginated many mutation (publishManyTranslationsConnection)"
+					},
+					{
+						"name": "publishManyTranslationsConnection",
+						"description": "Publish many Translation documents",
+						"args": [
+							{
+								"name": "after",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "before",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "first",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "from",
+								"description": "Stage to find matching documents in",
+								"type": {
+									"kind": "ENUM",
+									"name": "Stage",
+									"ofType": null
+								},
+								"defaultValue": "DRAFT",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "last",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "locales",
+								"description": "Document localizations to publish",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "publishBase",
+								"description": "Whether to publish the base document",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "skip",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "to",
+								"description": "Stages to publish documents to",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Stage",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[PUBLISHED]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Identifies documents in each stage to be published",
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationManyWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "withDefaultLocale",
+								"description": "Whether to include the default locale when publishBase is true",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "TranslationConnection",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "publishPage",
 						"description": "Publish one page",
 						"args": [
@@ -7358,6 +7800,103 @@
 						"type": {
 							"kind": "OBJECT",
 							"name": "Seo",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishTranslation",
+						"description": "Publish one translation",
+						"args": [
+							{
+								"name": "locales",
+								"description": "Optional localizations to publish",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "publishBase",
+								"description": "Whether to publish the base document",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "to",
+								"description": "Publishing target stage",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Stage",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[PUBLISHED]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Document to publish",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationWhereUniqueInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "withDefaultLocale",
+								"description": "Whether to include the default locale when publishBase is set",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "Translation",
 							"ofType": null
 						},
 						"isDeprecated": false,
@@ -7804,6 +8343,127 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "schedulePublishTranslation",
+						"description": "Schedule to publish one translation",
+						"args": [
+							{
+								"name": "locales",
+								"description": "Optional localizations to publish",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "publishBase",
+								"description": "Whether to publish the base document",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "releaseAt",
+								"description": "Release at point in time, will create new release containing this operation",
+								"type": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "releaseId",
+								"description": "Optionally attach this scheduled operation to an existing release",
+								"type": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "to",
+								"description": "Publishing target stage",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Stage",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[PUBLISHED]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Document to publish",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationWhereUniqueInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "withDefaultLocale",
+								"description": "Whether to include the default locale when publishBase is set",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "Translation",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "scheduleUnpublishAsset",
 						"description": "Unpublish one asset from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only.",
 						"args": [
@@ -8202,6 +8862,115 @@
 						"type": {
 							"kind": "OBJECT",
 							"name": "Seo",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "scheduleUnpublishTranslation",
+						"description": "Unpublish one translation from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only.",
+						"args": [
+							{
+								"name": "from",
+								"description": "Stages to unpublish document from",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Stage",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[PUBLISHED]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "locales",
+								"description": "Optional locales to unpublish. Unpublishing the default locale will completely remove the document from the selected stages",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "releaseAt",
+								"description": "Release at point in time, will create new release containing this operation",
+								"type": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "releaseId",
+								"description": "Optionally attach this scheduled operation to an existing release",
+								"type": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "unpublishBase",
+								"description": "Unpublish complete document including default localization and relations from stages. Can be disabled.",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Document to unpublish",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationWhereUniqueInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "Translation",
 							"ofType": null
 						},
 						"isDeprecated": false,
@@ -9197,6 +9966,248 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "unpublishManyTranslations",
+						"description": "Unpublish many Translation documents",
+						"args": [
+							{
+								"name": "from",
+								"description": "Stages to unpublish documents from",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Stage",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[PUBLISHED]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "locales",
+								"description": "Locales to unpublish",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "unpublishBase",
+								"description": "Whether to unpublish the base document and default localization",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Identifies documents in each stage",
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationManyWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "BatchPayload",
+								"ofType": null
+							}
+						},
+						"isDeprecated": true,
+						"deprecationReason": "Please use the new paginated many mutation (unpublishManyTranslationsConnection)"
+					},
+					{
+						"name": "unpublishManyTranslationsConnection",
+						"description": "Find many Translation documents that match criteria in specified stage and unpublish from target stages",
+						"args": [
+							{
+								"name": "after",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "before",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "first",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "from",
+								"description": "Stages to unpublish documents from",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Stage",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[PUBLISHED]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "last",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "locales",
+								"description": "Locales to unpublish",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "skip",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "stage",
+								"description": "Stage to find matching documents in",
+								"type": {
+									"kind": "ENUM",
+									"name": "Stage",
+									"ofType": null
+								},
+								"defaultValue": "DRAFT",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "unpublishBase",
+								"description": "Whether to unpublish the base document and default localization",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Identifies documents in draft stage",
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationManyWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "TranslationConnection",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "unpublishPage",
 						"description": "Unpublish one page from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only.",
 						"args": [
@@ -9414,6 +10425,91 @@
 						"type": {
 							"kind": "OBJECT",
 							"name": "Seo",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "unpublishTranslation",
+						"description": "Unpublish one translation from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only.",
+						"args": [
+							{
+								"name": "from",
+								"description": "Stages to unpublish document from",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Stage",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[PUBLISHED]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "locales",
+								"description": "Optional locales to unpublish. Unpublishing the default locale will completely remove the document from the selected stages",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "unpublishBase",
+								"description": "Unpublish complete document including default localization and relations from stages. Can be disabled.",
+								"type": {
+									"kind": "SCALAR",
+									"name": "Boolean",
+									"ofType": null
+								},
+								"defaultValue": "true",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Document to unpublish",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationWhereUniqueInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "Translation",
 							"ofType": null
 						},
 						"isDeprecated": false,
@@ -10065,6 +11161,156 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "updateManyTranslations",
+						"description": "Update many translations",
+						"args": [
+							{
+								"name": "data",
+								"description": "Updates to document content",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationUpdateManyInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Documents to apply update on",
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationManyWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "BatchPayload",
+								"ofType": null
+							}
+						},
+						"isDeprecated": true,
+						"deprecationReason": "Please use the new paginated many mutation (updateManyTranslationsConnection)"
+					},
+					{
+						"name": "updateManyTranslationsConnection",
+						"description": "Update many Translation documents",
+						"args": [
+							{
+								"name": "after",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "before",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "data",
+								"description": "Updates to document content",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationUpdateManyInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "first",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "last",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "skip",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": "Documents to apply update on",
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationManyWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "TranslationConnection",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "updatePage",
 						"description": "Update one page",
 						"args": [
@@ -10239,6 +11485,51 @@
 						"type": {
 							"kind": "OBJECT",
 							"name": "Seo",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updateTranslation",
+						"description": "Update one translation",
+						"args": [
+							{
+								"name": "data",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationUpdateInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationWhereUniqueInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "Translation",
 							"ofType": null
 						},
 						"isDeprecated": false,
@@ -10423,6 +11714,51 @@
 						},
 						"isDeprecated": false,
 						"deprecationReason": null
+					},
+					{
+						"name": "upsertTranslation",
+						"description": "Upsert one translation",
+						"args": [
+							{
+								"name": "upsert",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationUpsertInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationWhereUniqueInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "Translation",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
 					}
 				],
 				"inputFields": null,
@@ -10500,6 +11836,11 @@
 					{
 						"kind": "OBJECT",
 						"name": "Seo",
+						"ofType": null
+					},
+					{
+						"kind": "OBJECT",
+						"name": "Translation",
 						"ofType": null
 					},
 					{
@@ -19346,6 +20687,394 @@
 						"deprecationReason": null
 					},
 					{
+						"name": "translation",
+						"description": "Retrieve a single translation",
+						"args": [
+							{
+								"name": "locales",
+								"description": "Defines which locales should be returned.\n\nNote that `Translation` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.\nThe first locale matching the provided list will be returned, entries with non matching locales will be filtered out.\n\nThis argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Locale",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[en]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "stage",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "ENUM",
+										"name": "Stage",
+										"ofType": null
+									}
+								},
+								"defaultValue": "PUBLISHED",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "TranslationWhereUniqueInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "Translation",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "translationVersion",
+						"description": "Retrieve document version",
+						"args": [
+							{
+								"name": "where",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "INPUT_OBJECT",
+										"name": "VersionWhereInput",
+										"ofType": null
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "DocumentVersion",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "translations",
+						"description": "Retrieve multiple translations",
+						"args": [
+							{
+								"name": "after",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "before",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "first",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "last",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "locales",
+								"description": "Defines which locales should be returned.\n\nNote that `Translation` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.\nThe first locale matching the provided list will be returned, entries with non matching locales will be filtered out.\n\nThis argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Locale",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[en]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "orderBy",
+								"description": null,
+								"type": {
+									"kind": "ENUM",
+									"name": "TranslationOrderByInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "skip",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "stage",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "ENUM",
+										"name": "Stage",
+										"ofType": null
+									}
+								},
+								"defaultValue": "PUBLISHED",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": null,
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "LIST",
+								"name": null,
+								"ofType": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "OBJECT",
+										"name": "Translation",
+										"ofType": null
+									}
+								}
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "translationsConnection",
+						"description": "Retrieve multiple translations using the Relay connection interface",
+						"args": [
+							{
+								"name": "after",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "before",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "first",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "last",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "locales",
+								"description": "Defines which locales should be returned.\n\nNote that `Translation` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.\nThe first locale matching the provided list will be returned, entries with non matching locales will be filtered out.\n\nThis argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Locale",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[en]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "orderBy",
+								"description": null,
+								"type": {
+									"kind": "ENUM",
+									"name": "TranslationOrderByInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "skip",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "stage",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "ENUM",
+										"name": "Stage",
+										"ofType": null
+									}
+								},
+								"defaultValue": "PUBLISHED",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": null,
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "TranslationConnection",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
 						"name": "user",
 						"description": "Retrieve a single user",
 						"args": [
@@ -20459,6 +22188,11 @@
 					{
 						"kind": "OBJECT",
 						"name": "Seo",
+						"ofType": null
+					},
+					{
+						"kind": "OBJECT",
+						"name": "Translation",
 						"ofType": null
 					}
 				]
@@ -31421,6 +33155,3629 @@
 						"deprecationReason": null
 					}
 				],
+				"possibleTypes": null
+			},
+			{
+				"kind": "OBJECT",
+				"name": "Translation",
+				"description": null,
+				"fields": [
+					{
+						"name": "createdAt",
+						"description": "The time the document was created",
+						"args": [
+							{
+								"name": "variation",
+								"description": "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "ENUM",
+										"name": "SystemDateTimeFieldVariation",
+										"ofType": null
+									}
+								},
+								"defaultValue": "COMBINED",
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "SCALAR",
+								"name": "DateTime",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdBy",
+						"description": "User that created this document",
+						"args": [
+							{
+								"name": "locales",
+								"description": "Allows to optionally override locale filtering behaviour in the query's subtree.\n\nNote that `createdBy` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.\nFor related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.\n\nThis argument will overwrite any existing locale filtering defined in the query's tree for the subtree.",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "User",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "documentInStages",
+						"description": "Get the document in other stages",
+						"args": [
+							{
+								"name": "includeCurrent",
+								"description": "Decides if the current stage should be included or not",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "SCALAR",
+										"name": "Boolean",
+										"ofType": null
+									}
+								},
+								"defaultValue": "false",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "inheritLocale",
+								"description": "Decides if the documents should match the parent documents locale or should use the fallback order defined in the tree",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "SCALAR",
+										"name": "Boolean",
+										"ofType": null
+									}
+								},
+								"defaultValue": "false",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "stages",
+								"description": "Potential stages that should be returned",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Stage",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[DRAFT, PUBLISHED]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "LIST",
+								"name": null,
+								"ofType": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "OBJECT",
+										"name": "Translation",
+										"ofType": null
+									}
+								}
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "history",
+						"description": "List of Translation versions",
+						"args": [
+							{
+								"name": "limit",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "SCALAR",
+										"name": "Int",
+										"ofType": null
+									}
+								},
+								"defaultValue": "10",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "skip",
+								"description": null,
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "SCALAR",
+										"name": "Int",
+										"ofType": null
+									}
+								},
+								"defaultValue": "0",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "stageOverride",
+								"description": "This is optional and can be used to fetch the document version history for a specific stage instead of the current one",
+								"type": {
+									"kind": "ENUM",
+									"name": "Stage",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "LIST",
+								"name": null,
+								"ofType": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "OBJECT",
+										"name": "Version",
+										"ofType": null
+									}
+								}
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id",
+						"description": "The unique identifier",
+						"args": [],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "SCALAR",
+								"name": "ID",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key",
+						"description": null,
+						"args": [],
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "locale",
+						"description": "System Locale field",
+						"args": [],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "ENUM",
+								"name": "Locale",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "localizations",
+						"description": "Get the other localizations for this document",
+						"args": [
+							{
+								"name": "includeCurrent",
+								"description": "Decides if the current locale should be included or not",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "SCALAR",
+										"name": "Boolean",
+										"ofType": null
+									}
+								},
+								"defaultValue": "false",
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "locales",
+								"description": "Potential locales that should be returned",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "LIST",
+										"name": null,
+										"ofType": {
+											"kind": "NON_NULL",
+											"name": null,
+											"ofType": {
+												"kind": "ENUM",
+												"name": "Locale",
+												"ofType": null
+											}
+										}
+									}
+								},
+								"defaultValue": "[en, de_DE]",
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "LIST",
+								"name": null,
+								"ofType": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "OBJECT",
+										"name": "Translation",
+										"ofType": null
+									}
+								}
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt",
+						"description": "The time the document was published. Null on documents in draft stage.",
+						"args": [
+							{
+								"name": "variation",
+								"description": "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "ENUM",
+										"name": "SystemDateTimeFieldVariation",
+										"ofType": null
+									}
+								},
+								"defaultValue": "COMBINED",
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedBy",
+						"description": "User that last published this document",
+						"args": [
+							{
+								"name": "locales",
+								"description": "Allows to optionally override locale filtering behaviour in the query's subtree.\n\nNote that `publishedBy` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.\nFor related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.\n\nThis argument will overwrite any existing locale filtering defined in the query's tree for the subtree.",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "User",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "scheduledIn",
+						"description": null,
+						"args": [
+							{
+								"name": "after",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "before",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "first",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "last",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "locales",
+								"description": "Allows to optionally override locale filtering behaviour in the query's subtree.\n\nNote that `scheduledIn` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.\nFor related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.\n\nThis argument will overwrite any existing locale filtering defined in the query's tree for the subtree.",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "skip",
+								"description": null,
+								"type": {
+									"kind": "SCALAR",
+									"name": "Int",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							},
+							{
+								"name": "where",
+								"description": null,
+								"type": {
+									"kind": "INPUT_OBJECT",
+									"name": "ScheduledOperationWhereInput",
+									"ofType": null
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "LIST",
+								"name": null,
+								"ofType": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "OBJECT",
+										"name": "ScheduledOperation",
+										"ofType": null
+									}
+								}
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "stage",
+						"description": "System stage field",
+						"args": [],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "ENUM",
+								"name": "Stage",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt",
+						"description": "The time the document was updated",
+						"args": [
+							{
+								"name": "variation",
+								"description": "Variation of DateTime field to return, allows value from base document, current localization, or combined by returning the newer value of both",
+								"type": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "ENUM",
+										"name": "SystemDateTimeFieldVariation",
+										"ofType": null
+									}
+								},
+								"defaultValue": "COMBINED",
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "SCALAR",
+								"name": "DateTime",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedBy",
+						"description": "User that last updated this document",
+						"args": [
+							{
+								"name": "locales",
+								"description": "Allows to optionally override locale filtering behaviour in the query's subtree.\n\nNote that `updatedBy` is a model without localized fields and will not be affected directly by this argument, however the locales will be passed on to any relational fields in the query's subtree for filtering.\nFor related models with localized fields in the query's subtree, the first locale matching the provided list of locales will be returned, entries with non matching locales will be filtered out.\n\nThis argument will overwrite any existing locale filtering defined in the query's tree for the subtree.",
+								"type": {
+									"kind": "LIST",
+									"name": null,
+									"ofType": {
+										"kind": "NON_NULL",
+										"name": null,
+										"ofType": {
+											"kind": "ENUM",
+											"name": "Locale",
+											"ofType": null
+										}
+									}
+								},
+								"defaultValue": null,
+								"isDeprecated": false,
+								"deprecationReason": null
+							}
+						],
+						"type": {
+							"kind": "OBJECT",
+							"name": "User",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value",
+						"description": null,
+						"args": [],
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"inputFields": null,
+				"interfaces": [
+					{
+						"kind": "INTERFACE",
+						"name": "Node",
+						"ofType": null
+					}
+				],
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationConnectInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "position",
+						"description": "Allow to specify document position in list of connected documents, will default to appending at end of list",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "ConnectPositionInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "where",
+						"description": "Document to connect",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationWhereUniqueInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "OBJECT",
+				"name": "TranslationConnection",
+				"description": "A connection to a list of items.",
+				"fields": [
+					{
+						"name": "aggregate",
+						"description": null,
+						"args": [],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "Aggregate",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "edges",
+						"description": "A list of edges.",
+						"args": [],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "LIST",
+								"name": null,
+								"ofType": {
+									"kind": "NON_NULL",
+									"name": null,
+									"ofType": {
+										"kind": "OBJECT",
+										"name": "TranslationEdge",
+										"ofType": null
+									}
+								}
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "pageInfo",
+						"description": "Information to aid in pagination.",
+						"args": [],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "PageInfo",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"inputFields": null,
+				"interfaces": [],
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationCreateInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "createdAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "localizations",
+						"description": "Inline mutations for managing document localizations excluding the default locale",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "TranslationCreateLocalizationsInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value",
+						"description": "value input for default locale (en)",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationCreateLocalizationDataInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "createdAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationCreateLocalizationInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "data",
+						"description": "Localization input",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationCreateLocalizationDataInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "locale",
+						"description": null,
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "ENUM",
+								"name": "Locale",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationCreateLocalizationsInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "create",
+						"description": "Create localizations for the newly-created document",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationCreateLocalizationInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationCreateManyInlineInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "connect",
+						"description": "Connect multiple existing Translation documents",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereUniqueInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "create",
+						"description": "Create and connect multiple existing Translation documents",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationCreateInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationCreateOneInlineInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "connect",
+						"description": "Connect one existing Translation document",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "TranslationWhereUniqueInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "create",
+						"description": "Create and connect one Translation document",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "TranslationCreateInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "OBJECT",
+				"name": "TranslationEdge",
+				"description": "An edge in a connection.",
+				"fields": [
+					{
+						"name": "cursor",
+						"description": "A cursor for use in pagination.",
+						"args": [],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "SCALAR",
+								"name": "String",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "node",
+						"description": "The item at the end of the edge.",
+						"args": [],
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "Translation",
+								"ofType": null
+							}
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"inputFields": null,
+				"interfaces": [],
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationManyWhereInput",
+				"description": "Identifies documents",
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "AND",
+						"description": "Logical AND on all given filters.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "NOT",
+						"description": "Logical NOT on all given filters combined by AND.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "OR",
+						"description": "Logical OR on all given filters.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "_search",
+						"description": "Contains search across all appropriate fields.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_gt",
+						"description": "All values greater than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_gte",
+						"description": "All values greater than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_lt",
+						"description": "All values less than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_lte",
+						"description": "All values less than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdBy",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "UserWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_contains",
+						"description": "All values containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_ends_with",
+						"description": "All values ending with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not_contains",
+						"description": "All values not containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not_ends_with",
+						"description": "All values not ending with the given string",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not_starts_with",
+						"description": "All values not starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_starts_with",
+						"description": "All values starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_contains",
+						"description": "All values containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_ends_with",
+						"description": "All values ending with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_contains",
+						"description": "All values not containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_ends_with",
+						"description": "All values not ending with the given string",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_starts_with",
+						"description": "All values not starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_starts_with",
+						"description": "All values starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_gt",
+						"description": "All values greater than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_gte",
+						"description": "All values greater than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_lt",
+						"description": "All values less than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_lte",
+						"description": "All values less than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedBy",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "UserWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "scheduledIn_every",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "ScheduledOperationWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "scheduledIn_none",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "ScheduledOperationWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "scheduledIn_some",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "ScheduledOperationWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_gt",
+						"description": "All values greater than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_gte",
+						"description": "All values greater than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_lt",
+						"description": "All values less than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_lte",
+						"description": "All values less than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedBy",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "UserWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "ENUM",
+				"name": "TranslationOrderByInput",
+				"description": null,
+				"fields": null,
+				"inputFields": null,
+				"interfaces": null,
+				"enumValues": [
+					{
+						"name": "createdAt_ASC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_DESC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_ASC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_DESC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_ASC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_DESC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_ASC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_DESC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_ASC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_DESC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_ASC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_DESC",
+						"description": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "key",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "localizations",
+						"description": "Manage document localizations",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "TranslationUpdateLocalizationsInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value",
+						"description": "value input for default locale (en)",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateLocalizationDataInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "value",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateLocalizationInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "data",
+						"description": null,
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationUpdateLocalizationDataInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "locale",
+						"description": null,
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "ENUM",
+								"name": "Locale",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateLocalizationsInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "create",
+						"description": "Localizations to create",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationCreateLocalizationInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "delete",
+						"description": "Localizations to delete",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "ENUM",
+									"name": "Locale",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "update",
+						"description": "Localizations to update",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationUpdateLocalizationInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "upsert",
+						"description": null,
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationUpsertLocalizationInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateManyInlineInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "connect",
+						"description": "Connect multiple existing Translation documents",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationConnectInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "create",
+						"description": "Create and connect multiple Translation documents",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationCreateInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "delete",
+						"description": "Delete multiple Translation documents",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereUniqueInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "disconnect",
+						"description": "Disconnect multiple Translation documents",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereUniqueInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "set",
+						"description": "Override currently-connected documents with multiple existing Translation documents",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereUniqueInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "update",
+						"description": "Update multiple Translation documents",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationUpdateWithNestedWhereUniqueInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "upsert",
+						"description": "Upsert multiple Translation documents",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationUpsertWithNestedWhereUniqueInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateManyInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "localizations",
+						"description": "Optional updates to localizations",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "TranslationUpdateManyLocalizationsInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value",
+						"description": "value input for default locale (en)",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateManyLocalizationDataInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "value",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateManyLocalizationInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "data",
+						"description": null,
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationUpdateManyLocalizationDataInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "locale",
+						"description": null,
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "ENUM",
+								"name": "Locale",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateManyLocalizationsInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "update",
+						"description": "Localizations to update",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationUpdateManyLocalizationInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateManyWithNestedWhereInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "data",
+						"description": "Update many input",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationUpdateManyInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "where",
+						"description": "Document search",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationWhereInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateOneInlineInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "connect",
+						"description": "Connect existing Translation document",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "TranslationWhereUniqueInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "create",
+						"description": "Create and connect one Translation document",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "TranslationCreateInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "delete",
+						"description": "Delete currently connected Translation document",
+						"type": {
+							"kind": "SCALAR",
+							"name": "Boolean",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "disconnect",
+						"description": "Disconnect currently connected Translation document",
+						"type": {
+							"kind": "SCALAR",
+							"name": "Boolean",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "update",
+						"description": "Update single Translation document",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "TranslationUpdateWithNestedWhereUniqueInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "upsert",
+						"description": "Upsert single Translation document",
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "TranslationUpsertWithNestedWhereUniqueInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpdateWithNestedWhereUniqueInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "data",
+						"description": "Document to update",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationUpdateInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "where",
+						"description": "Unique document search",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationWhereUniqueInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpsertInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "create",
+						"description": "Create document if it didn't exist",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationCreateInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "update",
+						"description": "Update document if it exists",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationUpdateInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpsertLocalizationInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "create",
+						"description": null,
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationCreateLocalizationDataInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "locale",
+						"description": null,
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "ENUM",
+								"name": "Locale",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "update",
+						"description": null,
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationUpdateLocalizationDataInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationUpsertWithNestedWhereUniqueInput",
+				"description": null,
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "data",
+						"description": "Upsert data",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationUpsertInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "where",
+						"description": "Unique document search",
+						"type": {
+							"kind": "NON_NULL",
+							"name": null,
+							"ofType": {
+								"kind": "INPUT_OBJECT",
+								"name": "TranslationWhereUniqueInput",
+								"ofType": null
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationWhereInput",
+				"description": "Identifies documents",
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "AND",
+						"description": "Logical AND on all given filters.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "NOT",
+						"description": "Logical NOT on all given filters combined by AND.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "OR",
+						"description": "Logical OR on all given filters.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "INPUT_OBJECT",
+									"name": "TranslationWhereInput",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "_search",
+						"description": "Contains search across all appropriate fields.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_gt",
+						"description": "All values greater than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_gte",
+						"description": "All values greater than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_lt",
+						"description": "All values less than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_lte",
+						"description": "All values less than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdAt_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "createdBy",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "UserWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_contains",
+						"description": "All values containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_ends_with",
+						"description": "All values ending with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not_contains",
+						"description": "All values not containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not_ends_with",
+						"description": "All values not ending with the given string",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "ID",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_not_starts_with",
+						"description": "All values not starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "id_starts_with",
+						"description": "All values starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_contains",
+						"description": "All values containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_ends_with",
+						"description": "All values ending with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_contains",
+						"description": "All values not containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_ends_with",
+						"description": "All values not ending with the given string",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_not_starts_with",
+						"description": "All values not starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key_starts_with",
+						"description": "All values starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_gt",
+						"description": "All values greater than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_gte",
+						"description": "All values greater than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_lt",
+						"description": "All values less than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_lte",
+						"description": "All values less than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedAt_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "publishedBy",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "UserWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "scheduledIn_every",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "ScheduledOperationWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "scheduledIn_none",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "ScheduledOperationWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "scheduledIn_some",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "ScheduledOperationWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_gt",
+						"description": "All values greater than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_gte",
+						"description": "All values greater than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_lt",
+						"description": "All values less than the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_lte",
+						"description": "All values less than or equal the given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "DateTime",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedAt_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "DateTime",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "updatedBy",
+						"description": null,
+						"type": {
+							"kind": "INPUT_OBJECT",
+							"name": "UserWhereInput",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_contains",
+						"description": "All values containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_ends_with",
+						"description": "All values ending with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_in",
+						"description": "All values that are contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_not",
+						"description": "All values that are not equal to given value.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_not_contains",
+						"description": "All values not containing the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_not_ends_with",
+						"description": "All values not ending with the given string",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_not_in",
+						"description": "All values that are not contained in given list.",
+						"type": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "NON_NULL",
+								"name": null,
+								"ofType": {
+									"kind": "SCALAR",
+									"name": "String",
+									"ofType": null
+								}
+							}
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_not_starts_with",
+						"description": "All values not starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "value_starts_with",
+						"description": "All values starting with the given string.",
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
+				"possibleTypes": null
+			},
+			{
+				"kind": "INPUT_OBJECT",
+				"name": "TranslationWhereUniqueInput",
+				"description": "References Translation record uniquely",
+				"fields": null,
+				"inputFields": [
+					{
+						"name": "id",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "ID",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "key",
+						"description": null,
+						"type": {
+							"kind": "SCALAR",
+							"name": "String",
+							"ofType": null
+						},
+						"defaultValue": null,
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				],
+				"interfaces": null,
+				"enumValues": null,
 				"possibleTypes": null
 			},
 			{

--- a/packages/zerna.io/src/lib/cms/page/queries.ts
+++ b/packages/zerna.io/src/lib/cms/page/queries.ts
@@ -1,9 +1,9 @@
-import type { PageSummaryFragment } from '$lib/types/graphql';
+import type { PageSummaryFragment } from '$lib/generated/graphql';
 import { client } from '$lib/clients/graphql-client';
 import { gql } from 'graphql-request';
 
 export const allPages = gql`
-	query AllPages {
+	query {
 		pages {
 			key
 			seo {
@@ -15,7 +15,7 @@ export const allPages = gql`
 `;
 
 export const pageByKey = gql`
-	query PageBySlug($key: String!) {
+	query ($key: String!) {
 		page(where: { key: $key }) {
 			title
 			content {

--- a/packages/zerna.io/src/lib/cms/translation/queries.ts
+++ b/packages/zerna.io/src/lib/cms/translation/queries.ts
@@ -1,0 +1,32 @@
+import type { TranslationSummaryFragment } from '$lib/generated/graphql';
+import { client } from '$lib/clients/graphql-client';
+import { gql } from 'graphql-request';
+
+export const translationsByPageStart = gql`
+	query ($startWith: String!) {
+		translations(where: { key_starts_with: $startWith }) {
+			key
+			value
+		}
+	}
+`;
+
+export const getTranslationsByKeyStart = async (startWith: string) => {
+	try {
+		const { translations }: { translations: TranslationSummaryFragment[] } = await client.request(
+			translationsByPageStart,
+			{ startWith }
+		);
+		return {
+			status: 200,
+			body: { translations: Object.fromEntries(translations.map(({ key, value }) => [key, value])) }
+		};
+	} catch (e) {
+		return {
+			status: e.status,
+			body: {
+				error: 'error'
+			}
+		};
+	}
+};

--- a/packages/zerna.io/src/lib/cms/translation/schema.graphql
+++ b/packages/zerna.io/src/lib/cms/translation/schema.graphql
@@ -1,0 +1,4 @@
+fragment TranslationSummary on Translation {
+	key
+	value
+}

--- a/packages/zerna.io/src/lib/cms/translation/types.ts
+++ b/packages/zerna.io/src/lib/cms/translation/types.ts
@@ -1,0 +1,3 @@
+export interface TranslationUi {
+	[key: string]: string;
+}

--- a/packages/zerna.io/src/lib/generated/graphql.ts
+++ b/packages/zerna.io/src/lib/generated/graphql.ts
@@ -808,6 +808,8 @@ export type Mutation = {
 	createScheduledRelease?: Maybe<ScheduledRelease>;
 	/** Create one seo */
 	createSeo?: Maybe<Seo>;
+	/** Create one translation */
+	createTranslation?: Maybe<Translation>;
 	/** Delete one asset from _all_ existing stages. Returns deleted document. */
 	deleteAsset?: Maybe<Asset>;
 	/**
@@ -838,6 +840,13 @@ export type Mutation = {
 	deleteManySeos: BatchPayload;
 	/** Delete many Seo documents, return deleted documents */
 	deleteManySeosConnection: SeoConnection;
+	/**
+	 * Delete many Translation documents
+	 * @deprecated Please use the new paginated many mutation (deleteManyTranslationsConnection)
+	 */
+	deleteManyTranslations: BatchPayload;
+	/** Delete many Translation documents, return deleted documents */
+	deleteManyTranslationsConnection: TranslationConnection;
 	/** Delete one page from _all_ existing stages. Returns deleted document. */
 	deletePage?: Maybe<Page>;
 	/** Delete one post from _all_ existing stages. Returns deleted document. */
@@ -848,6 +857,8 @@ export type Mutation = {
 	deleteScheduledRelease?: Maybe<ScheduledRelease>;
 	/** Delete one seo from _all_ existing stages. Returns deleted document. */
 	deleteSeo?: Maybe<Seo>;
+	/** Delete one translation from _all_ existing stages. Returns deleted document. */
+	deleteTranslation?: Maybe<Translation>;
 	/** Publish one asset */
 	publishAsset?: Maybe<Asset>;
 	/**
@@ -878,12 +889,21 @@ export type Mutation = {
 	publishManySeos: BatchPayload;
 	/** Publish many Seo documents */
 	publishManySeosConnection: SeoConnection;
+	/**
+	 * Publish many Translation documents
+	 * @deprecated Please use the new paginated many mutation (publishManyTranslationsConnection)
+	 */
+	publishManyTranslations: BatchPayload;
+	/** Publish many Translation documents */
+	publishManyTranslationsConnection: TranslationConnection;
 	/** Publish one page */
 	publishPage?: Maybe<Page>;
 	/** Publish one post */
 	publishPost?: Maybe<Post>;
 	/** Publish one seo */
 	publishSeo?: Maybe<Seo>;
+	/** Publish one translation */
+	publishTranslation?: Maybe<Translation>;
 	/** Schedule to publish one asset */
 	schedulePublishAsset?: Maybe<Asset>;
 	/** Schedule to publish one page */
@@ -892,6 +912,8 @@ export type Mutation = {
 	schedulePublishPost?: Maybe<Post>;
 	/** Schedule to publish one seo */
 	schedulePublishSeo?: Maybe<Seo>;
+	/** Schedule to publish one translation */
+	schedulePublishTranslation?: Maybe<Translation>;
 	/** Unpublish one asset from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only. */
 	scheduleUnpublishAsset?: Maybe<Asset>;
 	/** Unpublish one page from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only. */
@@ -900,6 +922,8 @@ export type Mutation = {
 	scheduleUnpublishPost?: Maybe<Post>;
 	/** Unpublish one seo from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only. */
 	scheduleUnpublishSeo?: Maybe<Seo>;
+	/** Unpublish one translation from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only. */
+	scheduleUnpublishTranslation?: Maybe<Translation>;
 	/** Unpublish one asset from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only. */
 	unpublishAsset?: Maybe<Asset>;
 	/**
@@ -930,12 +954,21 @@ export type Mutation = {
 	unpublishManySeos: BatchPayload;
 	/** Find many Seo documents that match criteria in specified stage and unpublish from target stages */
 	unpublishManySeosConnection: SeoConnection;
+	/**
+	 * Unpublish many Translation documents
+	 * @deprecated Please use the new paginated many mutation (unpublishManyTranslationsConnection)
+	 */
+	unpublishManyTranslations: BatchPayload;
+	/** Find many Translation documents that match criteria in specified stage and unpublish from target stages */
+	unpublishManyTranslationsConnection: TranslationConnection;
 	/** Unpublish one page from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only. */
 	unpublishPage?: Maybe<Page>;
 	/** Unpublish one post from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only. */
 	unpublishPost?: Maybe<Post>;
 	/** Unpublish one seo from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only. */
 	unpublishSeo?: Maybe<Seo>;
+	/** Unpublish one translation from selected stages. Unpublish either the complete document with its relations, localizations and base data or specific localizations only. */
+	unpublishTranslation?: Maybe<Translation>;
 	/** Update one asset */
 	updateAsset?: Maybe<Asset>;
 	/**
@@ -966,6 +999,13 @@ export type Mutation = {
 	updateManySeos: BatchPayload;
 	/** Update many Seo documents */
 	updateManySeosConnection: SeoConnection;
+	/**
+	 * Update many translations
+	 * @deprecated Please use the new paginated many mutation (updateManyTranslationsConnection)
+	 */
+	updateManyTranslations: BatchPayload;
+	/** Update many Translation documents */
+	updateManyTranslationsConnection: TranslationConnection;
 	/** Update one page */
 	updatePage?: Maybe<Page>;
 	/** Update one post */
@@ -974,6 +1014,8 @@ export type Mutation = {
 	updateScheduledRelease?: Maybe<ScheduledRelease>;
 	/** Update one seo */
 	updateSeo?: Maybe<Seo>;
+	/** Update one translation */
+	updateTranslation?: Maybe<Translation>;
 	/** Upsert one asset */
 	upsertAsset?: Maybe<Asset>;
 	/** Upsert one page */
@@ -982,6 +1024,8 @@ export type Mutation = {
 	upsertPost?: Maybe<Post>;
 	/** Upsert one seo */
 	upsertSeo?: Maybe<Seo>;
+	/** Upsert one translation */
+	upsertTranslation?: Maybe<Translation>;
 };
 
 export type MutationCreateAssetArgs = {
@@ -1002,6 +1046,10 @@ export type MutationCreateScheduledReleaseArgs = {
 
 export type MutationCreateSeoArgs = {
 	data: SeoCreateInput;
+};
+
+export type MutationCreateTranslationArgs = {
+	data: TranslationCreateInput;
 };
 
 export type MutationDeleteAssetArgs = {
@@ -1060,6 +1108,19 @@ export type MutationDeleteManySeosConnectionArgs = {
 	where?: InputMaybe<SeoManyWhereInput>;
 };
 
+export type MutationDeleteManyTranslationsArgs = {
+	where?: InputMaybe<TranslationManyWhereInput>;
+};
+
+export type MutationDeleteManyTranslationsConnectionArgs = {
+	after?: InputMaybe<Scalars['ID']>;
+	before?: InputMaybe<Scalars['ID']>;
+	first?: InputMaybe<Scalars['Int']>;
+	last?: InputMaybe<Scalars['Int']>;
+	skip?: InputMaybe<Scalars['Int']>;
+	where?: InputMaybe<TranslationManyWhereInput>;
+};
+
 export type MutationDeletePageArgs = {
 	where: PageWhereUniqueInput;
 };
@@ -1078,6 +1139,10 @@ export type MutationDeleteScheduledReleaseArgs = {
 
 export type MutationDeleteSeoArgs = {
 	where: SeoWhereUniqueInput;
+};
+
+export type MutationDeleteTranslationArgs = {
+	where: TranslationWhereUniqueInput;
 };
 
 export type MutationPublishAssetArgs = {
@@ -1170,6 +1235,28 @@ export type MutationPublishManySeosConnectionArgs = {
 	withDefaultLocale?: InputMaybe<Scalars['Boolean']>;
 };
 
+export type MutationPublishManyTranslationsArgs = {
+	locales?: InputMaybe<Array<Locale>>;
+	publishBase?: InputMaybe<Scalars['Boolean']>;
+	to?: Array<Stage>;
+	where?: InputMaybe<TranslationManyWhereInput>;
+	withDefaultLocale?: InputMaybe<Scalars['Boolean']>;
+};
+
+export type MutationPublishManyTranslationsConnectionArgs = {
+	after?: InputMaybe<Scalars['ID']>;
+	before?: InputMaybe<Scalars['ID']>;
+	first?: InputMaybe<Scalars['Int']>;
+	from?: InputMaybe<Stage>;
+	last?: InputMaybe<Scalars['Int']>;
+	locales?: InputMaybe<Array<Locale>>;
+	publishBase?: InputMaybe<Scalars['Boolean']>;
+	skip?: InputMaybe<Scalars['Int']>;
+	to?: Array<Stage>;
+	where?: InputMaybe<TranslationManyWhereInput>;
+	withDefaultLocale?: InputMaybe<Scalars['Boolean']>;
+};
+
 export type MutationPublishPageArgs = {
 	locales?: InputMaybe<Array<Locale>>;
 	publishBase?: InputMaybe<Scalars['Boolean']>;
@@ -1188,6 +1275,14 @@ export type MutationPublishSeoArgs = {
 	publishBase?: InputMaybe<Scalars['Boolean']>;
 	to?: Array<Stage>;
 	where: SeoWhereUniqueInput;
+	withDefaultLocale?: InputMaybe<Scalars['Boolean']>;
+};
+
+export type MutationPublishTranslationArgs = {
+	locales?: InputMaybe<Array<Locale>>;
+	publishBase?: InputMaybe<Scalars['Boolean']>;
+	to?: Array<Stage>;
+	where: TranslationWhereUniqueInput;
 	withDefaultLocale?: InputMaybe<Scalars['Boolean']>;
 };
 
@@ -1228,6 +1323,16 @@ export type MutationSchedulePublishSeoArgs = {
 	withDefaultLocale?: InputMaybe<Scalars['Boolean']>;
 };
 
+export type MutationSchedulePublishTranslationArgs = {
+	locales?: InputMaybe<Array<Locale>>;
+	publishBase?: InputMaybe<Scalars['Boolean']>;
+	releaseAt?: InputMaybe<Scalars['DateTime']>;
+	releaseId?: InputMaybe<Scalars['String']>;
+	to?: Array<Stage>;
+	where: TranslationWhereUniqueInput;
+	withDefaultLocale?: InputMaybe<Scalars['Boolean']>;
+};
+
 export type MutationScheduleUnpublishAssetArgs = {
 	from?: Array<Stage>;
 	locales?: InputMaybe<Array<Locale>>;
@@ -1260,6 +1365,15 @@ export type MutationScheduleUnpublishSeoArgs = {
 	releaseId?: InputMaybe<Scalars['String']>;
 	unpublishBase?: InputMaybe<Scalars['Boolean']>;
 	where: SeoWhereUniqueInput;
+};
+
+export type MutationScheduleUnpublishTranslationArgs = {
+	from?: Array<Stage>;
+	locales?: InputMaybe<Array<Locale>>;
+	releaseAt?: InputMaybe<Scalars['DateTime']>;
+	releaseId?: InputMaybe<Scalars['String']>;
+	unpublishBase?: InputMaybe<Scalars['Boolean']>;
+	where: TranslationWhereUniqueInput;
 };
 
 export type MutationUnpublishAssetArgs = {
@@ -1345,6 +1459,26 @@ export type MutationUnpublishManySeosConnectionArgs = {
 	where?: InputMaybe<SeoManyWhereInput>;
 };
 
+export type MutationUnpublishManyTranslationsArgs = {
+	from?: Array<Stage>;
+	locales?: InputMaybe<Array<Locale>>;
+	unpublishBase?: InputMaybe<Scalars['Boolean']>;
+	where?: InputMaybe<TranslationManyWhereInput>;
+};
+
+export type MutationUnpublishManyTranslationsConnectionArgs = {
+	after?: InputMaybe<Scalars['ID']>;
+	before?: InputMaybe<Scalars['ID']>;
+	first?: InputMaybe<Scalars['Int']>;
+	from?: Array<Stage>;
+	last?: InputMaybe<Scalars['Int']>;
+	locales?: InputMaybe<Array<Locale>>;
+	skip?: InputMaybe<Scalars['Int']>;
+	stage?: InputMaybe<Stage>;
+	unpublishBase?: InputMaybe<Scalars['Boolean']>;
+	where?: InputMaybe<TranslationManyWhereInput>;
+};
+
 export type MutationUnpublishPageArgs = {
 	from?: Array<Stage>;
 	locales?: InputMaybe<Array<Locale>>;
@@ -1362,6 +1496,13 @@ export type MutationUnpublishSeoArgs = {
 	locales?: InputMaybe<Array<Locale>>;
 	unpublishBase?: InputMaybe<Scalars['Boolean']>;
 	where: SeoWhereUniqueInput;
+};
+
+export type MutationUnpublishTranslationArgs = {
+	from?: Array<Stage>;
+	locales?: InputMaybe<Array<Locale>>;
+	unpublishBase?: InputMaybe<Scalars['Boolean']>;
+	where: TranslationWhereUniqueInput;
 };
 
 export type MutationUpdateAssetArgs = {
@@ -1429,6 +1570,21 @@ export type MutationUpdateManySeosConnectionArgs = {
 	where?: InputMaybe<SeoManyWhereInput>;
 };
 
+export type MutationUpdateManyTranslationsArgs = {
+	data: TranslationUpdateManyInput;
+	where?: InputMaybe<TranslationManyWhereInput>;
+};
+
+export type MutationUpdateManyTranslationsConnectionArgs = {
+	after?: InputMaybe<Scalars['ID']>;
+	before?: InputMaybe<Scalars['ID']>;
+	data: TranslationUpdateManyInput;
+	first?: InputMaybe<Scalars['Int']>;
+	last?: InputMaybe<Scalars['Int']>;
+	skip?: InputMaybe<Scalars['Int']>;
+	where?: InputMaybe<TranslationManyWhereInput>;
+};
+
 export type MutationUpdatePageArgs = {
 	data: PageUpdateInput;
 	where: PageWhereUniqueInput;
@@ -1449,6 +1605,11 @@ export type MutationUpdateSeoArgs = {
 	where: SeoWhereUniqueInput;
 };
 
+export type MutationUpdateTranslationArgs = {
+	data: TranslationUpdateInput;
+	where: TranslationWhereUniqueInput;
+};
+
 export type MutationUpsertAssetArgs = {
 	upsert: AssetUpsertInput;
 	where: AssetWhereUniqueInput;
@@ -1467,6 +1628,11 @@ export type MutationUpsertPostArgs = {
 export type MutationUpsertSeoArgs = {
 	upsert: SeoUpsertInput;
 	where: SeoWhereUniqueInput;
+};
+
+export type MutationUpsertTranslationArgs = {
+	upsert: TranslationUpsertInput;
+	where: TranslationWhereUniqueInput;
 };
 
 /** An object with an ID */
@@ -2429,6 +2595,14 @@ export type Query = {
 	seos: Array<Seo>;
 	/** Retrieve multiple seos using the Relay connection interface */
 	seosConnection: SeoConnection;
+	/** Retrieve a single translation */
+	translation?: Maybe<Translation>;
+	/** Retrieve document version */
+	translationVersion?: Maybe<DocumentVersion>;
+	/** Retrieve multiple translations */
+	translations: Array<Translation>;
+	/** Retrieve multiple translations using the Relay connection interface */
+	translationsConnection: TranslationConnection;
 	/** Retrieve a single user */
 	user?: Maybe<User>;
 	/** Retrieve multiple users */
@@ -2639,6 +2813,40 @@ export type QuerySeosConnectionArgs = {
 	where?: InputMaybe<SeoWhereInput>;
 };
 
+export type QueryTranslationArgs = {
+	locales?: Array<Locale>;
+	stage?: Stage;
+	where: TranslationWhereUniqueInput;
+};
+
+export type QueryTranslationVersionArgs = {
+	where: VersionWhereInput;
+};
+
+export type QueryTranslationsArgs = {
+	after?: InputMaybe<Scalars['String']>;
+	before?: InputMaybe<Scalars['String']>;
+	first?: InputMaybe<Scalars['Int']>;
+	last?: InputMaybe<Scalars['Int']>;
+	locales?: Array<Locale>;
+	orderBy?: InputMaybe<TranslationOrderByInput>;
+	skip?: InputMaybe<Scalars['Int']>;
+	stage?: Stage;
+	where?: InputMaybe<TranslationWhereInput>;
+};
+
+export type QueryTranslationsConnectionArgs = {
+	after?: InputMaybe<Scalars['String']>;
+	before?: InputMaybe<Scalars['String']>;
+	first?: InputMaybe<Scalars['Int']>;
+	last?: InputMaybe<Scalars['Int']>;
+	locales?: Array<Locale>;
+	orderBy?: InputMaybe<TranslationOrderByInput>;
+	skip?: InputMaybe<Scalars['Int']>;
+	stage?: Stage;
+	where?: InputMaybe<TranslationWhereInput>;
+};
+
 export type QueryUserArgs = {
 	locales?: Array<Locale>;
 	stage?: Stage;
@@ -2770,7 +2978,7 @@ export type ScheduledOperationUpdatedByArgs = {
 	locales?: InputMaybe<Array<Locale>>;
 };
 
-export type ScheduledOperationAffectedDocument = Asset | Page | Post | Seo;
+export type ScheduledOperationAffectedDocument = Asset | Page | Post | Seo | Translation;
 
 export type ScheduledOperationConnectInput = {
 	/** Allow to specify document position in list of connected documents, will default to appending at end of list */
@@ -4299,6 +4507,511 @@ export enum SystemDateTimeFieldVariation {
 	Localization = 'LOCALIZATION'
 }
 
+export type Translation = Node & {
+	__typename?: 'Translation';
+	/** The time the document was created */
+	createdAt: Scalars['DateTime'];
+	/** User that created this document */
+	createdBy?: Maybe<User>;
+	/** Get the document in other stages */
+	documentInStages: Array<Translation>;
+	/** List of Translation versions */
+	history: Array<Version>;
+	/** The unique identifier */
+	id: Scalars['ID'];
+	key?: Maybe<Scalars['String']>;
+	/** System Locale field */
+	locale: Locale;
+	/** Get the other localizations for this document */
+	localizations: Array<Translation>;
+	/** The time the document was published. Null on documents in draft stage. */
+	publishedAt?: Maybe<Scalars['DateTime']>;
+	/** User that last published this document */
+	publishedBy?: Maybe<User>;
+	scheduledIn: Array<ScheduledOperation>;
+	/** System stage field */
+	stage: Stage;
+	/** The time the document was updated */
+	updatedAt: Scalars['DateTime'];
+	/** User that last updated this document */
+	updatedBy?: Maybe<User>;
+	value?: Maybe<Scalars['String']>;
+};
+
+export type TranslationCreatedAtArgs = {
+	variation?: SystemDateTimeFieldVariation;
+};
+
+export type TranslationCreatedByArgs = {
+	locales?: InputMaybe<Array<Locale>>;
+};
+
+export type TranslationDocumentInStagesArgs = {
+	includeCurrent?: Scalars['Boolean'];
+	inheritLocale?: Scalars['Boolean'];
+	stages?: Array<Stage>;
+};
+
+export type TranslationHistoryArgs = {
+	limit?: Scalars['Int'];
+	skip?: Scalars['Int'];
+	stageOverride?: InputMaybe<Stage>;
+};
+
+export type TranslationLocalizationsArgs = {
+	includeCurrent?: Scalars['Boolean'];
+	locales?: Array<Locale>;
+};
+
+export type TranslationPublishedAtArgs = {
+	variation?: SystemDateTimeFieldVariation;
+};
+
+export type TranslationPublishedByArgs = {
+	locales?: InputMaybe<Array<Locale>>;
+};
+
+export type TranslationScheduledInArgs = {
+	after?: InputMaybe<Scalars['String']>;
+	before?: InputMaybe<Scalars['String']>;
+	first?: InputMaybe<Scalars['Int']>;
+	last?: InputMaybe<Scalars['Int']>;
+	locales?: InputMaybe<Array<Locale>>;
+	skip?: InputMaybe<Scalars['Int']>;
+	where?: InputMaybe<ScheduledOperationWhereInput>;
+};
+
+export type TranslationUpdatedAtArgs = {
+	variation?: SystemDateTimeFieldVariation;
+};
+
+export type TranslationUpdatedByArgs = {
+	locales?: InputMaybe<Array<Locale>>;
+};
+
+export type TranslationConnectInput = {
+	/** Allow to specify document position in list of connected documents, will default to appending at end of list */
+	position?: InputMaybe<ConnectPositionInput>;
+	/** Document to connect */
+	where: TranslationWhereUniqueInput;
+};
+
+/** A connection to a list of items. */
+export type TranslationConnection = {
+	__typename?: 'TranslationConnection';
+	aggregate: Aggregate;
+	/** A list of edges. */
+	edges: Array<TranslationEdge>;
+	/** Information to aid in pagination. */
+	pageInfo: PageInfo;
+};
+
+export type TranslationCreateInput = {
+	createdAt?: InputMaybe<Scalars['DateTime']>;
+	key?: InputMaybe<Scalars['String']>;
+	/** Inline mutations for managing document localizations excluding the default locale */
+	localizations?: InputMaybe<TranslationCreateLocalizationsInput>;
+	updatedAt?: InputMaybe<Scalars['DateTime']>;
+	/** value input for default locale (en) */
+	value?: InputMaybe<Scalars['String']>;
+};
+
+export type TranslationCreateLocalizationDataInput = {
+	createdAt?: InputMaybe<Scalars['DateTime']>;
+	updatedAt?: InputMaybe<Scalars['DateTime']>;
+	value?: InputMaybe<Scalars['String']>;
+};
+
+export type TranslationCreateLocalizationInput = {
+	/** Localization input */
+	data: TranslationCreateLocalizationDataInput;
+	locale: Locale;
+};
+
+export type TranslationCreateLocalizationsInput = {
+	/** Create localizations for the newly-created document */
+	create?: InputMaybe<Array<TranslationCreateLocalizationInput>>;
+};
+
+export type TranslationCreateManyInlineInput = {
+	/** Connect multiple existing Translation documents */
+	connect?: InputMaybe<Array<TranslationWhereUniqueInput>>;
+	/** Create and connect multiple existing Translation documents */
+	create?: InputMaybe<Array<TranslationCreateInput>>;
+};
+
+export type TranslationCreateOneInlineInput = {
+	/** Connect one existing Translation document */
+	connect?: InputMaybe<TranslationWhereUniqueInput>;
+	/** Create and connect one Translation document */
+	create?: InputMaybe<TranslationCreateInput>;
+};
+
+/** An edge in a connection. */
+export type TranslationEdge = {
+	__typename?: 'TranslationEdge';
+	/** A cursor for use in pagination. */
+	cursor: Scalars['String'];
+	/** The item at the end of the edge. */
+	node: Translation;
+};
+
+/** Identifies documents */
+export type TranslationManyWhereInput = {
+	/** Logical AND on all given filters. */
+	AND?: InputMaybe<Array<TranslationWhereInput>>;
+	/** Logical NOT on all given filters combined by AND. */
+	NOT?: InputMaybe<Array<TranslationWhereInput>>;
+	/** Logical OR on all given filters. */
+	OR?: InputMaybe<Array<TranslationWhereInput>>;
+	/** Contains search across all appropriate fields. */
+	_search?: InputMaybe<Scalars['String']>;
+	createdAt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than the given value. */
+	createdAt_gt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than or equal the given value. */
+	createdAt_gte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are contained in given list. */
+	createdAt_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	/** All values less than the given value. */
+	createdAt_lt?: InputMaybe<Scalars['DateTime']>;
+	/** All values less than or equal the given value. */
+	createdAt_lte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not equal to given value. */
+	createdAt_not?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not contained in given list. */
+	createdAt_not_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	createdBy?: InputMaybe<UserWhereInput>;
+	id?: InputMaybe<Scalars['ID']>;
+	/** All values containing the given string. */
+	id_contains?: InputMaybe<Scalars['ID']>;
+	/** All values ending with the given string. */
+	id_ends_with?: InputMaybe<Scalars['ID']>;
+	/** All values that are contained in given list. */
+	id_in?: InputMaybe<Array<Scalars['ID']>>;
+	/** All values that are not equal to given value. */
+	id_not?: InputMaybe<Scalars['ID']>;
+	/** All values not containing the given string. */
+	id_not_contains?: InputMaybe<Scalars['ID']>;
+	/** All values not ending with the given string */
+	id_not_ends_with?: InputMaybe<Scalars['ID']>;
+	/** All values that are not contained in given list. */
+	id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+	/** All values not starting with the given string. */
+	id_not_starts_with?: InputMaybe<Scalars['ID']>;
+	/** All values starting with the given string. */
+	id_starts_with?: InputMaybe<Scalars['ID']>;
+	key?: InputMaybe<Scalars['String']>;
+	/** All values containing the given string. */
+	key_contains?: InputMaybe<Scalars['String']>;
+	/** All values ending with the given string. */
+	key_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are contained in given list. */
+	key_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values that are not equal to given value. */
+	key_not?: InputMaybe<Scalars['String']>;
+	/** All values not containing the given string. */
+	key_not_contains?: InputMaybe<Scalars['String']>;
+	/** All values not ending with the given string */
+	key_not_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are not contained in given list. */
+	key_not_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values not starting with the given string. */
+	key_not_starts_with?: InputMaybe<Scalars['String']>;
+	/** All values starting with the given string. */
+	key_starts_with?: InputMaybe<Scalars['String']>;
+	publishedAt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than the given value. */
+	publishedAt_gt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than or equal the given value. */
+	publishedAt_gte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are contained in given list. */
+	publishedAt_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	/** All values less than the given value. */
+	publishedAt_lt?: InputMaybe<Scalars['DateTime']>;
+	/** All values less than or equal the given value. */
+	publishedAt_lte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not equal to given value. */
+	publishedAt_not?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not contained in given list. */
+	publishedAt_not_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	publishedBy?: InputMaybe<UserWhereInput>;
+	scheduledIn_every?: InputMaybe<ScheduledOperationWhereInput>;
+	scheduledIn_none?: InputMaybe<ScheduledOperationWhereInput>;
+	scheduledIn_some?: InputMaybe<ScheduledOperationWhereInput>;
+	updatedAt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than the given value. */
+	updatedAt_gt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than or equal the given value. */
+	updatedAt_gte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are contained in given list. */
+	updatedAt_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	/** All values less than the given value. */
+	updatedAt_lt?: InputMaybe<Scalars['DateTime']>;
+	/** All values less than or equal the given value. */
+	updatedAt_lte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not equal to given value. */
+	updatedAt_not?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not contained in given list. */
+	updatedAt_not_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	updatedBy?: InputMaybe<UserWhereInput>;
+};
+
+export enum TranslationOrderByInput {
+	CreatedAtAsc = 'createdAt_ASC',
+	CreatedAtDesc = 'createdAt_DESC',
+	IdAsc = 'id_ASC',
+	IdDesc = 'id_DESC',
+	KeyAsc = 'key_ASC',
+	KeyDesc = 'key_DESC',
+	PublishedAtAsc = 'publishedAt_ASC',
+	PublishedAtDesc = 'publishedAt_DESC',
+	UpdatedAtAsc = 'updatedAt_ASC',
+	UpdatedAtDesc = 'updatedAt_DESC',
+	ValueAsc = 'value_ASC',
+	ValueDesc = 'value_DESC'
+}
+
+export type TranslationUpdateInput = {
+	key?: InputMaybe<Scalars['String']>;
+	/** Manage document localizations */
+	localizations?: InputMaybe<TranslationUpdateLocalizationsInput>;
+	/** value input for default locale (en) */
+	value?: InputMaybe<Scalars['String']>;
+};
+
+export type TranslationUpdateLocalizationDataInput = {
+	value?: InputMaybe<Scalars['String']>;
+};
+
+export type TranslationUpdateLocalizationInput = {
+	data: TranslationUpdateLocalizationDataInput;
+	locale: Locale;
+};
+
+export type TranslationUpdateLocalizationsInput = {
+	/** Localizations to create */
+	create?: InputMaybe<Array<TranslationCreateLocalizationInput>>;
+	/** Localizations to delete */
+	delete?: InputMaybe<Array<Locale>>;
+	/** Localizations to update */
+	update?: InputMaybe<Array<TranslationUpdateLocalizationInput>>;
+	upsert?: InputMaybe<Array<TranslationUpsertLocalizationInput>>;
+};
+
+export type TranslationUpdateManyInlineInput = {
+	/** Connect multiple existing Translation documents */
+	connect?: InputMaybe<Array<TranslationConnectInput>>;
+	/** Create and connect multiple Translation documents */
+	create?: InputMaybe<Array<TranslationCreateInput>>;
+	/** Delete multiple Translation documents */
+	delete?: InputMaybe<Array<TranslationWhereUniqueInput>>;
+	/** Disconnect multiple Translation documents */
+	disconnect?: InputMaybe<Array<TranslationWhereUniqueInput>>;
+	/** Override currently-connected documents with multiple existing Translation documents */
+	set?: InputMaybe<Array<TranslationWhereUniqueInput>>;
+	/** Update multiple Translation documents */
+	update?: InputMaybe<Array<TranslationUpdateWithNestedWhereUniqueInput>>;
+	/** Upsert multiple Translation documents */
+	upsert?: InputMaybe<Array<TranslationUpsertWithNestedWhereUniqueInput>>;
+};
+
+export type TranslationUpdateManyInput = {
+	/** Optional updates to localizations */
+	localizations?: InputMaybe<TranslationUpdateManyLocalizationsInput>;
+	/** value input for default locale (en) */
+	value?: InputMaybe<Scalars['String']>;
+};
+
+export type TranslationUpdateManyLocalizationDataInput = {
+	value?: InputMaybe<Scalars['String']>;
+};
+
+export type TranslationUpdateManyLocalizationInput = {
+	data: TranslationUpdateManyLocalizationDataInput;
+	locale: Locale;
+};
+
+export type TranslationUpdateManyLocalizationsInput = {
+	/** Localizations to update */
+	update?: InputMaybe<Array<TranslationUpdateManyLocalizationInput>>;
+};
+
+export type TranslationUpdateManyWithNestedWhereInput = {
+	/** Update many input */
+	data: TranslationUpdateManyInput;
+	/** Document search */
+	where: TranslationWhereInput;
+};
+
+export type TranslationUpdateOneInlineInput = {
+	/** Connect existing Translation document */
+	connect?: InputMaybe<TranslationWhereUniqueInput>;
+	/** Create and connect one Translation document */
+	create?: InputMaybe<TranslationCreateInput>;
+	/** Delete currently connected Translation document */
+	delete?: InputMaybe<Scalars['Boolean']>;
+	/** Disconnect currently connected Translation document */
+	disconnect?: InputMaybe<Scalars['Boolean']>;
+	/** Update single Translation document */
+	update?: InputMaybe<TranslationUpdateWithNestedWhereUniqueInput>;
+	/** Upsert single Translation document */
+	upsert?: InputMaybe<TranslationUpsertWithNestedWhereUniqueInput>;
+};
+
+export type TranslationUpdateWithNestedWhereUniqueInput = {
+	/** Document to update */
+	data: TranslationUpdateInput;
+	/** Unique document search */
+	where: TranslationWhereUniqueInput;
+};
+
+export type TranslationUpsertInput = {
+	/** Create document if it didn't exist */
+	create: TranslationCreateInput;
+	/** Update document if it exists */
+	update: TranslationUpdateInput;
+};
+
+export type TranslationUpsertLocalizationInput = {
+	create: TranslationCreateLocalizationDataInput;
+	locale: Locale;
+	update: TranslationUpdateLocalizationDataInput;
+};
+
+export type TranslationUpsertWithNestedWhereUniqueInput = {
+	/** Upsert data */
+	data: TranslationUpsertInput;
+	/** Unique document search */
+	where: TranslationWhereUniqueInput;
+};
+
+/** Identifies documents */
+export type TranslationWhereInput = {
+	/** Logical AND on all given filters. */
+	AND?: InputMaybe<Array<TranslationWhereInput>>;
+	/** Logical NOT on all given filters combined by AND. */
+	NOT?: InputMaybe<Array<TranslationWhereInput>>;
+	/** Logical OR on all given filters. */
+	OR?: InputMaybe<Array<TranslationWhereInput>>;
+	/** Contains search across all appropriate fields. */
+	_search?: InputMaybe<Scalars['String']>;
+	createdAt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than the given value. */
+	createdAt_gt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than or equal the given value. */
+	createdAt_gte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are contained in given list. */
+	createdAt_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	/** All values less than the given value. */
+	createdAt_lt?: InputMaybe<Scalars['DateTime']>;
+	/** All values less than or equal the given value. */
+	createdAt_lte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not equal to given value. */
+	createdAt_not?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not contained in given list. */
+	createdAt_not_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	createdBy?: InputMaybe<UserWhereInput>;
+	id?: InputMaybe<Scalars['ID']>;
+	/** All values containing the given string. */
+	id_contains?: InputMaybe<Scalars['ID']>;
+	/** All values ending with the given string. */
+	id_ends_with?: InputMaybe<Scalars['ID']>;
+	/** All values that are contained in given list. */
+	id_in?: InputMaybe<Array<Scalars['ID']>>;
+	/** All values that are not equal to given value. */
+	id_not?: InputMaybe<Scalars['ID']>;
+	/** All values not containing the given string. */
+	id_not_contains?: InputMaybe<Scalars['ID']>;
+	/** All values not ending with the given string */
+	id_not_ends_with?: InputMaybe<Scalars['ID']>;
+	/** All values that are not contained in given list. */
+	id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+	/** All values not starting with the given string. */
+	id_not_starts_with?: InputMaybe<Scalars['ID']>;
+	/** All values starting with the given string. */
+	id_starts_with?: InputMaybe<Scalars['ID']>;
+	key?: InputMaybe<Scalars['String']>;
+	/** All values containing the given string. */
+	key_contains?: InputMaybe<Scalars['String']>;
+	/** All values ending with the given string. */
+	key_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are contained in given list. */
+	key_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values that are not equal to given value. */
+	key_not?: InputMaybe<Scalars['String']>;
+	/** All values not containing the given string. */
+	key_not_contains?: InputMaybe<Scalars['String']>;
+	/** All values not ending with the given string */
+	key_not_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are not contained in given list. */
+	key_not_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values not starting with the given string. */
+	key_not_starts_with?: InputMaybe<Scalars['String']>;
+	/** All values starting with the given string. */
+	key_starts_with?: InputMaybe<Scalars['String']>;
+	publishedAt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than the given value. */
+	publishedAt_gt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than or equal the given value. */
+	publishedAt_gte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are contained in given list. */
+	publishedAt_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	/** All values less than the given value. */
+	publishedAt_lt?: InputMaybe<Scalars['DateTime']>;
+	/** All values less than or equal the given value. */
+	publishedAt_lte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not equal to given value. */
+	publishedAt_not?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not contained in given list. */
+	publishedAt_not_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	publishedBy?: InputMaybe<UserWhereInput>;
+	scheduledIn_every?: InputMaybe<ScheduledOperationWhereInput>;
+	scheduledIn_none?: InputMaybe<ScheduledOperationWhereInput>;
+	scheduledIn_some?: InputMaybe<ScheduledOperationWhereInput>;
+	updatedAt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than the given value. */
+	updatedAt_gt?: InputMaybe<Scalars['DateTime']>;
+	/** All values greater than or equal the given value. */
+	updatedAt_gte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are contained in given list. */
+	updatedAt_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	/** All values less than the given value. */
+	updatedAt_lt?: InputMaybe<Scalars['DateTime']>;
+	/** All values less than or equal the given value. */
+	updatedAt_lte?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not equal to given value. */
+	updatedAt_not?: InputMaybe<Scalars['DateTime']>;
+	/** All values that are not contained in given list. */
+	updatedAt_not_in?: InputMaybe<Array<Scalars['DateTime']>>;
+	updatedBy?: InputMaybe<UserWhereInput>;
+	value?: InputMaybe<Scalars['String']>;
+	/** All values containing the given string. */
+	value_contains?: InputMaybe<Scalars['String']>;
+	/** All values ending with the given string. */
+	value_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are contained in given list. */
+	value_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values that are not equal to given value. */
+	value_not?: InputMaybe<Scalars['String']>;
+	/** All values not containing the given string. */
+	value_not_contains?: InputMaybe<Scalars['String']>;
+	/** All values not ending with the given string */
+	value_not_ends_with?: InputMaybe<Scalars['String']>;
+	/** All values that are not contained in given list. */
+	value_not_in?: InputMaybe<Array<Scalars['String']>>;
+	/** All values not starting with the given string. */
+	value_not_starts_with?: InputMaybe<Scalars['String']>;
+	/** All values starting with the given string. */
+	value_starts_with?: InputMaybe<Scalars['String']>;
+};
+
+/** References Translation record uniquely */
+export type TranslationWhereUniqueInput = {
+	id?: InputMaybe<Scalars['ID']>;
+	key?: InputMaybe<Scalars['String']>;
+};
+
 export type UnpublishLocaleInput = {
 	/** Locales to unpublish */
 	locale: Locale;
@@ -4769,4 +5482,10 @@ export type PageSummaryFragment = {
 	key?: string | null;
 	content?: { __typename?: 'RichText'; html: string } | null;
 	seo?: { __typename?: 'Seo'; description?: string | null; keywords: Array<string> } | null;
+};
+
+export type TranslationSummaryFragment = {
+	__typename?: 'Translation';
+	key?: string | null;
+	value?: string | null;
 };

--- a/packages/zerna.io/src/routes/contact.svelte
+++ b/packages/zerna.io/src/routes/contact.svelte
@@ -7,7 +7,6 @@
 	import { FormElement } from '@ousia/application-ui/components';
 	import { FormElementVariant } from '@ousia/application-ui/constants';
 
-
 	const schema = yup.object().shape({
 		firstName: yup.string().required(),
 		lastName: yup.string().required(),

--- a/packages/zerna.io/src/routes/index.svelte
+++ b/packages/zerna.io/src/routes/index.svelte
@@ -1,48 +1,32 @@
+<script lang="ts">
+	import type { TranslationUi } from '$lib/cms/translation/types';
+
+	export let translations: TranslationUi;
+</script>
+
 <svelte:head>
 	<title>Zerna.io</title>
 </svelte:head>
 
-<section class="min-h-screen flex justify-center items-center overflow-hidden pt-8 sm:pt-0">
+<section class="flex justify-center items-center overflow-hidden pt-8 sm:pt-24 pb-8">
 	<div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
 		<div class="sm:text-center lg:text-left flex flex-col justify-center">
 			<h1 class="text-4xl tracking-tight font-extrabold text-white sm:text-6xl">
-				<span class="block">A better way to</span>
-				<span class="block bg-clip-text text-transparent bg-gradient-to-r from-teal-200 to-cyan-400"
-					>ship web apps</span
+				<span class="block">
+					{translations['landing.intro.betterWay.i']}
+				</span>
+				<span
+					class="block bg-clip-text text-transparent bg-gradient-to-r from-teal-200 to-cyan-400"
+				>
+					{translations['landing.intro.betterWay.ii']}</span
 				>
 			</h1>
 			<p class="text-base pt-3 text-gray-300 sm:text-xl sm:pt-5 lg:text-lg xl:text-xl">
 				Anim aute id magna aliqua ad ad non deserunt sunt. Qui irure qui Lorem cupidatat commodo.
 				Elit sunt amet fugiat veniam occaecat fugiat.
 			</p>
-			<div class="pt-10 sm:pt-12">
-				<form action="#">
-					<div class="sm:flex">
-						<div class="min-w-0 flex-1">
-							<label for="email" class="sr-only">Email address</label>
-							<input
-								id="email"
-								type="email"
-								placeholder="Enter your email"
-								class="block w-full px-4 py-3 rounded-md border-0 text-base text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-400 focus:ring-offset-gray-900"
-							/>
-						</div>
-						<div class="mt-3 sm:mt-0 sm:ml-3">
-							<button
-								type="submit"
-								class="block w-full py-3 px-4 rounded-md shadow bg-gradient-to-r from-teal-500 to-cyan-600 text-white font-medium hover:from-teal-600 hover:to-cyan-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-400 focus:ring-offset-gray-900"
-								>Start free trial</button
-							>
-						</div>
-					</div>
-					<p class="mt-3 text-sm text-gray-300 sm:mt-4">
-						Start your free 14-day trial, no credit card necessary. By providing your email, you
-						agree to our <a href="#" class="font-medium text-white">terms of service</a>.
-					</p>
-				</form>
-			</div>
 		</div>
-		<div>
+		<div class="pt-8 sm:pt-0">
 			<img
 				class="max-h-full"
 				src="https://tailwindui.com/img/component-images/cloud-illustration-teal-cyan.svg"
@@ -52,13 +36,339 @@
 	</div>
 </section>
 
-<section class="min-h-screen flex justify-center items-center overflow-hidden pt-8 sm:pt-0">
-	<div
-		class="bg-white w-full shadow-lg shadow-slate-100/40 overflow-hidden rounded-lg divide-y divide-gray-200"
-	>
-		<div class="px-4 py-5 sm:px-6" />
-		<div class="px-4 py-5 sm:p-6">
-			<div class="px-4 py-4 sm:px-6" />
+<section class="py-12 sm:py-20">
+	<div class="lg:text-center">
+		<h2 class="text-base text-cyan-400 font-semibold tracking-wide uppercase">Experience</h2>
+		<p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-gray-100 sm:text-4xl">
+			Wide Range of Industry Know-How
+		</p>
+		<p class="mt-4 text-xl text-gray-300 lg:mx-auto">
+			Lorem ipsum dolor sit amet consect adipisicing elit. Possimus magnam voluptatum cupiditate
+			veritatis in accusamus quisquam.
+		</p>
+	</div>
+	<div class="mt-10">
+		<dl class="space-y-10 md:space-y-0 md:grid md:grid-cols-2 md:gap-x-8 md:gap-y-10">
+			<div class="relative">
+				<dt>
+					<div
+						class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white"
+					>
+						<!-- Heroicon name: outline/globe-alt -->
+						<svg
+							class="h-6 w-6"
+							xmlns="http://www.w3.org/2000/svg"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
+							/>
+						</svg>
+					</div>
+					<p class="ml-16 text-lg leading-6 font-medium text-slate-100">
+						Competitive exchange rates
+					</p>
+				</dt>
+				<dd class="mt-2 ml-16 text-base text-slate-300">
+					Lorem ipsum, dolor sit amet consectetur adipisicing elit. Maiores impedit perferendis
+					suscipit eaque, iste dolor cupiditate blanditiis ratione.
+				</dd>
+			</div>
+
+			<div class="relative">
+				<dt>
+					<div
+						class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white"
+					>
+						<!-- Heroicon name: outline/scale -->
+						<svg
+							class="h-6 w-6"
+							xmlns="http://www.w3.org/2000/svg"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"
+							/>
+						</svg>
+					</div>
+					<p class="ml-16 text-lg leading-6 font-medium text-slate-100">No hidden fees</p>
+				</dt>
+				<dd class="mt-2 ml-16 text-base text-slate-300">
+					Lorem ipsum, dolor sit amet consectetur adipisicing elit. Maiores impedit perferendis
+					suscipit eaque, iste dolor cupiditate blanditiis ratione.
+				</dd>
+			</div>
+
+			<div class="relative">
+				<dt>
+					<div
+						class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white"
+					>
+						<!-- Heroicon name: outline/lightning-bolt -->
+						<svg
+							class="h-6 w-6"
+							xmlns="http://www.w3.org/2000/svg"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M13 10V3L4 14h7v7l9-11h-7z"
+							/>
+						</svg>
+					</div>
+					<p class="ml-16 text-lg leading-6 font-medium text-slate-100">Transfers are instant</p>
+				</dt>
+				<dd class="mt-2 ml-16 text-base text-slate-300">
+					Lorem ipsum, dolor sit amet consectetur adipisicing elit. Maiores impedit perferendis
+					suscipit eaque, iste dolor cupiditate blanditiis ratione.
+				</dd>
+			</div>
+
+			<div class="relative">
+				<dt>
+					<div
+						class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white"
+					>
+						<!-- Heroicon name: outline/annotation -->
+						<svg
+							class="h-6 w-6"
+							xmlns="http://www.w3.org/2000/svg"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
+							/>
+						</svg>
+					</div>
+					<p class="ml-16 text-lg leading-6 font-medium text-slate-100">Mobile notifications</p>
+				</dt>
+				<dd class="mt-2 ml-16 text-base text-slate-300">
+					Lorem ipsum, dolor sit amet consectetur adipisicing elit. Maiores impedit perferendis
+					suscipit eaque, iste dolor cupiditate blanditiis ratione.
+				</dd>
+			</div>
+		</dl>
+	</div>
+</section>
+
+<section class="py-12 sm:py-20">
+	<div class="lg:text-center">
+		<h2 class="text-base text-cyan-400 font-semibold tracking-wide uppercase">Tech Stack</h2>
+		<p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-slate-100 sm:text-4xl">
+			How do we build our apps?
+		</p>
+		<p class="mt-4 text-xl text-slate-300 lg:mx-auto">
+			Lorem ipsum dolor sit amet consect adipisicing elit. Possimus magnam voluptatum cupiditate
+			veritatis in accusamus quisquam.
+		</p>
+	</div>
+	<div class="mt-8 grid grid-cols-2 gap-8 md:grid-cols-6 lg:grid-cols-5 mx-auto">
+		<div class="col-span-1 flex justify-center py-8 px-8">
+		  <img class="max-h-12" src="https://tailwindui.com/img/logos/transistor-logo-gray-400.svg" alt="Workcation">
 		</div>
+		<div class="col-span-1 flex justify-center py-8 px-8">
+		  <img class="max-h-12" src="https://tailwindui.com/img/logos/mirage-logo-gray-400.svg" alt="Mirage">
+		</div>
+		<div class="col-span-1 flex justify-center py-8 px-8">
+		  <img class="max-h-12" src="https://tailwindui.com/img/logos/tuple-logo-gray-400.svg" alt="Tuple">
+		</div>
+		<div class="col-span-1 flex justify-center py-8 px-8">
+		  <img class="max-h-12" src="https://tailwindui.com/img/logos/laravel-logo-gray-400.svg" alt="Laravel">
+		</div>
+		<div class="col-span-1 flex justify-center py-8 px-8">
+		  <img class="max-h-12" src="https://tailwindui.com/img/logos/statickit-logo-gray-400.svg" alt="StaticKit">
+		</div>
+		<div class="col-span-1 flex justify-center py-8 px-8">
+		  <img class="max-h-12" src="https://tailwindui.com/img/logos/statamic-logo-gray-400.svg" alt="Statamic">
+		</div>
+	  </div>
+</section>
+
+<section class="py-12 sm:py-20">
+	<div class="lg:text-center">
+		<h2 class="text-base text-cyan-400 font-semibold tracking-wide uppercase">Blog</h2>
+		<p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-slate-100 sm:text-4xl">
+			Our Recent Publications
+		</p>
+		<p class="mt-4 text-xl text-slate-300 lg:mx-auto">
+			Lorem ipsum dolor sit amet consect adipisicing elit. Possimus magnam voluptatum cupiditate
+			veritatis in accusamus quisquam.
+		</p>
+	</div>
+	<div class="grid gap-16 mt-12 lg:grid-cols-3 lg:gap-x-5 lg:gap-y-12">
+		<div class="flex flex-col overflow-hidden">
+			<div class="flex-1 pt-4 flex flex-col justify-between">
+				<div class="flex-1">
+					<span
+						class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800"
+					>
+						Badge
+					</span>
+					<a href="#" class="block mt-2">
+						<p class="text-xl font-semibold text-slate-100">Boost your conversion rate</p>
+						<p class="mt-3 text-base text-slate-300">
+							Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto accusantium
+							praesentium eius, ut atque fuga culpa, similique sequi cum eos quis dolorum.
+						</p>
+					</a>
+				</div>
+				<div class="mt-6 flex items-center">
+					<div class="flex-shrink-0">
+						<a href="#">
+							<span class="sr-only">Roel Aufderehar</span>
+							<img
+								class="h-10 w-10 rounded-full"
+								src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+								alt=""
+							/>
+						</a>
+					</div>
+					<div class="ml-3">
+						<p class="text-sm font-medium text-slate-100">
+							<a href="#" class="hover:underline"> Roel Aufderehar </a>
+						</p>
+						<div class="flex space-x-1 text-sm text-slate-300">
+							<time datetime="2020-03-16"> Mar 16, 2020 </time>
+							<span aria-hidden="true"> &middot; </span>
+							<span> 6 min read </span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="flex flex-col overflow-hidden">
+			<div class="flex-1 pt-4 flex flex-col justify-between">
+				<div class="flex-1">
+					<span
+						class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800"
+					>
+						Badge
+					</span>
+					<a href="#" class="block mt-2">
+						<p class="text-xl font-semibold text-slate-100">Boost your conversion rate</p>
+						<p class="mt-3 text-base text-slate-300">
+							Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto accusantium
+							praesentium eius, ut atque fuga culpa, similique sequi cum eos quis dolorum.
+						</p>
+					</a>
+				</div>
+				<div class="mt-6 flex items-center">
+					<div class="flex-shrink-0">
+						<a href="#">
+							<span class="sr-only">Roel Aufderehar</span>
+							<img
+								class="h-10 w-10 rounded-full"
+								src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+								alt=""
+							/>
+						</a>
+					</div>
+					<div class="ml-3">
+						<p class="text-sm font-medium text-slate-100">
+							<a href="#" class="hover:underline"> Roel Aufderehar </a>
+						</p>
+						<div class="flex space-x-1 text-sm text-slate-300">
+							<time datetime="2020-03-16"> Mar 16, 2020 </time>
+							<span aria-hidden="true"> &middot; </span>
+							<span> 6 min read </span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="flex flex-col overflow-hidden">
+			<div class="flex-1 pt-4 flex flex-col justify-between">
+				<div class="flex-1">
+					<span
+						class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800"
+					>
+						Badge
+					</span>
+					<a href="#" class="block mt-2">
+						<p class="text-xl font-semibold text-slate-100">Boost your conversion rate</p>
+						<p class="mt-3 text-base text-slate-300">
+							Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto accusantium
+							praesentium eius, ut atque fuga culpa, similique sequi cum eos quis dolorum.
+						</p>
+					</a>
+				</div>
+				<div class="mt-6 flex items-center">
+					<div class="flex-shrink-0">
+						<a href="#">
+							<span class="sr-only">Roel Aufderehar</span>
+							<img
+								class="h-10 w-10 rounded-full"
+								src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+								alt=""
+							/>
+						</a>
+					</div>
+					<div class="ml-3">
+						<p class="text-sm font-medium text-slate-100">
+							<a href="#" class="hover:underline"> Roel Aufderehar </a>
+						</p>
+						<div class="flex space-x-1 text-sm text-slate-300">
+							<time datetime="2020-03-16"> Mar 16, 2020 </time>
+							<span aria-hidden="true"> &middot; </span>
+							<span> 6 min read </span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</section>
+
+
+
+
+
+<section class="py-12 sm:py-20">
+	<div class="px-4 py-8 sm:px-8 sm:py-16 bg-indigo-600 rounded-sm">
+		<blockquote>
+			<div>
+				<svg
+					class="h-12 w-12 text-white opacity-25"
+					fill="currentColor"
+					viewBox="0 0 32 32"
+					aria-hidden="true"
+				>
+					<path
+						d="M9.352 4C4.456 7.456 1 13.12 1 19.36c0 5.088 3.072 8.064 6.624 8.064 3.36 0 5.856-2.688 5.856-5.856 0-3.168-2.208-5.472-5.088-5.472-.576 0-1.344.096-1.536.192.48-3.264 3.552-7.104 6.624-9.024L9.352 4zm16.512 0c-4.8 3.456-8.256 9.12-8.256 15.36 0 5.088 3.072 8.064 6.624 8.064 3.264 0 5.856-2.688 5.856-5.856 0-3.168-2.304-5.472-5.184-5.472-.576 0-1.248.096-1.44.192.48-3.264 3.456-7.104 6.528-9.024L25.864 4z"
+					/>
+				</svg>
+				<p class="mt-6 text-2xl font-medium text-white">
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed urna nulla vitae
+					laoreet augue. Amet feugiat est integer dolor auctor adipiscing nunc urna, sit.
+				</p>
+			</div>
+			<footer class="mt-6">
+				<p class="text-base font-medium text-white">Judith Black</p>
+				<p class="text-base font-medium text-indigo-100">CEO at PureInsights</p>
+			</footer>
+		</blockquote>
 	</div>
 </section>

--- a/packages/zerna.io/src/routes/index.ts
+++ b/packages/zerna.io/src/routes/index.ts
@@ -1,0 +1,5 @@
+import { getTranslationsByKeyStart } from '$lib/cms/translation/queries';
+
+export const get = async () => {
+	return getTranslationsByKeyStart('landing');
+};

--- a/packages/zerna.io/src/routes/terms.svelte
+++ b/packages/zerna.io/src/routes/terms.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { PageSummaryFragment } from '$lib/types/graphql';
+	import type { PageSummaryFragment } from '$lib/generated/graphql';
 	export let page: PageSummaryFragment;
 </script>
 
@@ -11,7 +11,7 @@
 
 <section class="grid justify-items-center overflow-hidden pt-8">
 	<h1 class="text-4xl tracking-tight font-extrabold text-white sm:text-6xl pb-12">{page.title}</h1>
-	<article class="bg-white overflow-hidden rounded-lg w-full max-w-5xl px-4 py-4 sm:px-6 prose">
+	<article class="w-full overflow-hidden max-w-5xl px-4 py-4 sm:px-6 prose prose-invert">
 		{@html page.content.html}
 	</article>
 </section>


### PR DESCRIPTION
- i18n integration via graphcms and local object transforms
- finish landing sections and add placeholder
- update graphql types with translations
- refactor graphql queries for page calls

closes #55